### PR TITLE
Encode spaces correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Encode spaces to "%20" instead of "+". This encoding fixes an issue where Conjur
+  variables that have spaces were not encoded correctly 
+  ([cyberark/ansible-conjur-collection#5](https://github.com/cyberark/ansible-conjur-collection/pull/5))
 
 ## v1.0.3
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-# v1.0.3
-## Update
+## Unreleased
+
+## v1.0.3
+### Changed
 - Updated documentation section to comply with sanity checks
 
-# v1.0.2
-## Added
+## v1.0.2
+### Added
 - Migrated code from Ansible conjur_variable lookup plugin
 - Added support to configure the use of the plugin via environment variables

--- a/plugins/lookup/conjur_variable.py
+++ b/plugins/lookup/conjur_variable.py
@@ -81,7 +81,7 @@ from base64 import b64encode
 from netrc import netrc
 from os import environ
 from time import time
-from ansible.module_utils.six.moves.urllib.parse import quote_plus
+from ansible.module_utils.six.moves.urllib.parse import quote
 import yaml
 
 from ansible.module_utils.urls import open_url
@@ -141,8 +141,8 @@ def _merge_dictionaries(*arg):
 
 # Use credentials to retrieve temporary authorization token
 def _fetch_conjur_token(conjur_url, account, username, api_key, validate_certs):
-    conjur_url = '{0}/authn/{1}/{2}/authenticate'.format(conjur_url, account, quote_plus(username))
-    display.vvvv('Authentication request to Conjur at: {0}, with user: {1}'.format(conjur_url, quote_plus(username)))
+    conjur_url = '{0}/authn/{1}/{2}/authenticate'.format(conjur_url, account, quote(username))
+    display.vvvv('Authentication request to Conjur at: {0}, with user: {1}'.format(conjur_url, quote(username)))
 
     response = open_url(conjur_url, data=api_key, method='POST', validate_certs=validate_certs)
     code = response.getcode()
@@ -158,7 +158,7 @@ def _fetch_conjur_variable(conjur_variable, token, conjur_url, account, validate
     token = b64encode(token)
     headers = {'Authorization': 'Token token="{0}"'.format(token.decode("utf-8"))}
 
-    url = '{0}/secrets/{1}/variable/{2}'.format(conjur_url, account, quote_plus(conjur_variable))
+    url = '{0}/secrets/{1}/variable/{2}'.format(conjur_url, account, quote(conjur_variable))
     display.vvvv('Conjur Variable URL: {0}'.format(url))
 
     response = open_url(url, headers=headers, method='GET', validate_certs=validate_certs)


### PR DESCRIPTION
Connected to ansible/awx#7191
Blocked by #7 

Previously we used `urllib.parse`'s `quote_plus` function
to encode strings. However, this method replaces spaces with
`+` instead of `%20` which resulted in a 404 Not Found error
as in the server side we interpret `%20` as a space and leave
the `+` as it is.

More info can be found in the definition of `quote_plus`: https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote_plus