### PR TITLE
Add automated tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-# v1.0.3
-## Update
+## [Unreleased]
+
+## [1.0.3] - 2020-04-18
+### Changed
 - Updated documentation section to comply with sanity checks
 
-# v1.0.2
-## Added
+## [1.0.2] - 2020-04-01
+### Added
 - Migrated code from Ansible conjur_variable lookup plugin
 - Added support to configure the use of the plugin via environment variables

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,14 @@ pipeline {
     buildDiscarder(logRotator(numToKeepStr: '30'))
   }
 
+  stage('Validate') {
+    parallel {
+      stage('Changelog') {
+        steps { sh './bin/parse-changelog.sh' }
+      }
+    }
+  }
+
   stages {
     stage('Run tests') {
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,25 @@
+#!/usr/bin/env groovy
+
+pipeline {
+  agent { label 'executor-v2' }
+
+  options {
+    timestamps()
+    buildDiscarder(logRotator(numToKeepStr: '30'))
+  }
+
+  stages {
+    stage('Run tests') {
+      steps {
+        sh './bin/test.sh'
+        junit 'tests/junit/*'
+      }
+    }
+  }
+
+  post {
+    always {
+      cleanupAndNotify(currentBuild.currentResult)
+    }
+  }
+}

--- a/bin/parse-changelog.sh
+++ b/bin/parse-changelog.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -ex
+
+docker run \
+  --rm \
+  --volume "${PWD}/CHANGELOG.md":/CHANGELOG.md \
+  cyberark/parse-a-changelog

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+
+cd "${PWD}/tests"
+./test.sh

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /cyberark
+
+# install ansible
+RUN apt-get update && \
+    apt-get install -y ansible
+
+# install python 3
+RUN apt-get update && \
+    apt-get install -y python3-pip && \
+    pip3 install --upgrade pip==9.0.3
+
+# install ansible and its test tool
+RUN pip3 install ansible testinfra
+
+# install docker installation requirements
+RUN apt-get update && \
+    apt-get install -y apt-transport-https \
+                       ca-certificates \
+                       curl \
+                       software-properties-common
+
+# install docker
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+RUN add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+       $(lsb_release -cs) \
+       stable"
+
+RUN apt-get update && \
+    apt-get -y install docker-ce

--- a/tests/Dockerfile_nginx
+++ b/tests/Dockerfile_nginx
@@ -1,0 +1,17 @@
+FROM nginx:1.13.3
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y iputils-ping \
+                       procps \
+                       openssl && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /etc/nginx/
+
+COPY proxy/ssl.conf /etc/ssl/openssl.cnf
+COPY proxy/default.conf /etc/nginx/conf.d/default.conf
+
+RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+    -config /etc/ssl/openssl.cnf -extensions v3_ca \
+    -keyout cert.key -out cert.crt

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,58 @@
+version: '3'
+services:
+  ansible:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    entrypoint: sleep
+    command: infinity
+    environment:
+      CONJUR_APPLIANCE_URL: http://conjur:3000
+      CONJUR_ACCOUNT: cucumber
+      CONJUR_AUTHN_LOGIN: host/ansible/ansible-master
+      CONJUR_AUTHN_API_KEY: ${ANSIBLE_MASTER_AUTHN_API_KEY}
+      COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
+      CONJUR_VERSION: 5
+      CONJUR_CERT_FILE: ${ANSIBLE_CONJUR_CERT_FILE}
+    volumes:
+      - ../plugins:/root/.ansible/plugins
+      - ..:/cyberark
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  pg:
+    image: postgres:9.4
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: password
+      POSTGRES_PASSWORD: StrongPass
+
+  conjur:
+    image: cyberark/conjur
+    command: server -a cucumber -p 3000
+    environment:
+      CONJUR_APPLIANCE_URL: http://localhost:3000
+      DATABASE_URL: postgres://postgres:StrongPass@pg/postgres
+      CONJUR_DATA_KEY: "W0BuL8iTr/7QvtjIluJbrb5LDAnmXzmcpxkqihO3dXA="
+    depends_on:
+      - pg
+
+  conjur_proxy:
+    build:
+      context: .
+      dockerfile: Dockerfile_nginx
+    entrypoint: nginx-debug -g 'daemon off;'
+    environment:
+      TERM: xterm
+    depends_on:
+      - conjur
+
+  conjur_cli:
+    image: cyberark/conjur-cli:5
+    entrypoint: sleep
+    command: infinity
+    environment:
+      CONJUR_APPLIANCE_URL: http://conjur:3000
+      CONJUR_ACCOUNT: cucumber
+      CONJUR_AUTHN_LOGIN: admin
+      CONJUR_AUTHN_API_KEY: ${CONJUR_ADMIN_AUTHN_API_KEY}
+    volumes:
+      - ./policy:/policy

--- a/tests/policy/root.yml
+++ b/tests/policy/root.yml
@@ -1,0 +1,21 @@
+---
+- !policy
+  id: ansible
+  annotations:
+    description: Policy for Ansible master
+  body:
+
+  - !host
+    id: ansible-master
+    annotations:
+      description: Host for running Ansible on remote targets
+
+  - &variables
+
+    - !variable
+      id: test-secret
+
+  - !permit
+    role: !host ansible-master
+    privileges: [ read, execute ]
+    resource: *variables

--- a/tests/proxy/default.conf
+++ b/tests/proxy/default.conf
@@ -1,0 +1,29 @@
+server {
+    listen 80;
+    return 301 https://conjur$request_uri;
+}
+
+server {
+    listen       443;
+    server_name  localhost;
+    ssl_certificate           /etc/nginx/cert.crt;
+    ssl_certificate_key       /etc/nginx/cert.key;
+
+    ssl on;
+    ssl_session_cache  builtin:1000  shared:SSL:10m;
+    ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
+    ssl_prefer_server_ciphers on;
+
+    access_log            /var/log/nginx/access.log;
+
+    location / {
+      proxy_pass http://conjur:3000;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+}

--- a/tests/proxy/ssl.conf
+++ b/tests/proxy/ssl.conf
@@ -1,0 +1,39 @@
+[req]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+x509_extensions = v3_ca # The extentions to add to the self signed cert
+req_extensions  = v3_req
+x509_extensions = usr_cert
+
+[ dn ]
+C=IL
+ST=Israel
+L=TLV
+O=Onyx
+OU=CyberArk
+CN=conjur-proxy-nginx
+
+[ usr_cert ]
+basicConstraints=CA:FALSE
+nsCertType                      = client, server, email
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth, codeSigning, emailProtection
+nsComment                       = "OpenSSL Generated Certificate"
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+[ v3_req ]
+extendedKeyUsage = serverAuth, clientAuth, codeSigning, emailProtection
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+[ v3_ca ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = localhost
+DNS.2 = conjur-proxy-nginx
+IP.1 = 127.0.0.1

--- a/tests/test_cases/retrieve-secret/playbook.yml
+++ b/tests/test_cases/retrieve-secret/playbook.yml
@@ -1,0 +1,9 @@
+---
+- name: Retrieve Conjur secret
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Retrieve Conjur secret
+      vars:
+        super_secret_key: "{{lookup('conjur_variable', 'ansible/test-secret')}}"
+      shell: echo "{{super_secret_key}}" > /conjur_secrets.txt

--- a/tests/test_cases/retrieve-secret/tests/test_default.py
+++ b/tests/test_cases/retrieve-secret/tests/test_default.py
@@ -1,0 +1,13 @@
+import testinfra.utils.ansible_runner
+import os
+
+testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '_ansible_1']
+
+def test_retrieved_secret(host):
+    secrets_file = host.file('/conjur_secrets.txt')
+
+    assert secrets_file.exists
+
+    result = host.check_output("cat /conjur_secrets.txt", shell=True)
+
+    assert result == "test_secret_password"


### PR DESCRIPTION
Connected to #6 

This PR adds automated tests to the project. It runs a playbook that retrieves a Conjur secret into an Ansible variable.

Additional tests can be added to the `test_cases` directory in a similar way.