### PR TITLE
Encode spaces and slashes correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 ### Fixed
 - Encode spaces to "%20" instead of "+". This encoding fixes an issue where Conjur
   variables that have spaces were not encoded correctly 
   ([cyberark/ansible-conjur-collection#5](https://github.com/cyberark/ansible-conjur-collection/pull/5))
 
-## v1.0.3
+## [1.0.3] - 2020-04-18
 ### Changed
 - Updated documentation section to comply with sanity checks
 
-## v1.0.2
-
+## [1.0.2] - 2020-04-01
 ### Added
 - Migrated code from Ansible conjur_variable lookup plugin
 - Added support to configure the use of the plugin via environment variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Encode spaces to "%20" instead of "+". This encoding fixes an issue where Conjur
   variables that have spaces were not encoded correctly 
-  ([cyberark/ansible-conjur-collection#5](https://github.com/cyberark/ansible-conjur-collection/pull/5))
+  ([cyberark/ansible-conjur-collection#12](https://github.com/cyberark/ansible-conjur-collection/issues/12))
 
 ## [1.0.3] - 2020-04-18
 ### Changed

--- a/tests/policy/root.yml
+++ b/tests/policy/root.yml
@@ -11,9 +11,8 @@
       description: Host for running Ansible on remote targets
 
   - &variables
-
-    - !variable
-      id: test-secret
+    - !variable test-secret
+    - !variable var with spaces
 
   - !permit
     role: !host ansible-master

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -63,6 +63,7 @@ function setup_conjur {
   docker-compose exec -T conjur_cli bash -c '
     conjur policy load root /policy/root.yml
     conjur variable values add ansible/test-secret test_secret_password
+    conjur variable values add "ansible/var with spaces" var_with_spaces_secret_password
   '
 }
 
@@ -80,8 +81,8 @@ function run_test_case {
       cd tests
       ansible-playbook test_cases/${test_case}/playbook.yml
       py.test --junitxml=./junit/${test_case} \
-        --connection docker \
-        -v test_cases/${test_case}/tests/test_default.py
+              --connection docker \
+              -v test_cases/${test_case}/tests/test_default.py
     "
   else
     echo ERROR: run_test called with no argument 1>&2

--- a/tests/test_cases/retrieve-variable-with-spaces-secret/playbook.yml
+++ b/tests/test_cases/retrieve-variable-with-spaces-secret/playbook.yml
@@ -1,0 +1,9 @@
+---
+- name: Retrieve Conjur secret with spaces in the variable name
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Retrieve Conjur secret with spaces in the variable name
+      vars:
+        super_secret_key: "{{lookup('conjur_variable', 'ansible/var with spaces')}}"
+      shell: echo "{{super_secret_key}}" > /conjur_secrets.txt

--- a/tests/test_cases/retrieve-variable-with-spaces-secret/tests/test_default.py
+++ b/tests/test_cases/retrieve-variable-with-spaces-secret/tests/test_default.py
@@ -1,0 +1,13 @@
+import testinfra.utils.ansible_runner
+import os
+
+testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '_ansible_1']
+
+def test_retrieved_secret(host):
+    secrets_file = host.file('/conjur_secrets.txt')
+
+    assert secrets_file.exists
+
+    result = host.check_output("cat /conjur_secrets.txt", shell=True)
+
+    assert result == "var_with_spaces_secret_password"


### PR DESCRIPTION
Connected to #12 

The `quote` method's default value for `safe` is '/' so it doesn't encode slashes
into "%2F" which is what the Conjur server expects. Thus, we need to use this
method with no safe characters. We can't use the method `quote_plus` (which encodes
slashes correctly) because it encodes spaces into the character '+' instead of "%20"
as expected by the Conjur server