### PR TITLE
Made ansible-galaxy release building use a Docker image

### DIFF
--- a/bin/build_release
+++ b/bin/build_release
@@ -2,8 +2,11 @@
 
 set -euo pipefail
 
-CURRENT_DIR=$(dirname $BASH_SOURCE)
+CURRENT_DIR="$(cd "$(dirname "$BASH_SOURCE")"; pwd)"
 
 pushd "$CURRENT_DIR/.." >/dev/null
-  ansible-galaxy collection build --force
+  docker run --rm -it \
+    -v "$CURRENT_DIR/..:/runner" \
+    ansible/ansible-runner \
+    ansible-galaxy collection build --force
 popd  >/dev/null


### PR DESCRIPTION
Without this, it's possible that the base OS doesn't have ansible-galaxy
installed and that the build will fail (Jenkins).

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation