### PR TITLE
Remove opening of input stream for release building

### DIFF
--- a/bin/build_release
+++ b/bin/build_release
@@ -5,7 +5,7 @@ set -euo pipefail
 CURRENT_DIR="$(cd "$(dirname "$BASH_SOURCE")"; pwd)"
 
 pushd "$CURRENT_DIR/.." >/dev/null
-  docker run --rm -it \
+  docker run --rm -t \
     -v "$CURRENT_DIR/..:/runner" \
     ansible/ansible-runner \
     ansible-galaxy collection build --force


### PR DESCRIPTION
Since Jenkins doesn't have an interactive terminal, we can't use that
flag with docker.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation