### PR TITLE
Support authn file path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # We don't care about test outputs
 tests/junit/
 tests/conjur.pem
+tests/access_token
 
 # We should never check in pycache directories
 **/__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Plugin support authenticating with access token provided by authn-k8s
+  ([cyberark/ansible-conjur-collection#23](https://github.com/cyberark/ansible-conjur-collection/issues/23))
 
 ## [1.0.5] - 2020-06-18
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ None.
 Fetch credentials from CyberArk Conjur using the controlling host's Conjur identity or environment variables.
 
 - The controlling host running Ansible has a Conjur identity. [More Information here](https://docs.conjur.org/latest/en/Content/Get%20Started/key_concepts/machine_identity.html) and here in [Conjur Ansible role project](https://github.com/cyberark/ansible-conjur-host-identity/)
-- Environment variables could be CONJUR_ACCOUNT, CONJUR_APPLIANCE_URL, CONJUR_CERT_FILE, CONJUR_AUTHN_LOGIN, CONJUR_AUTHN_API_KEY
+- Environment variables could be CONJUR_ACCOUNT, CONJUR_APPLIANCE_URL, CONJUR_CERT_FILE, CONJUR_AUTHN_LOGIN, CONJUR_AUTHN_API_KEY, CONJUR_AUTHN_TOKEN_FILE
 
 #### Example Playbook
 

--- a/tests/test_cases/retrieve-variable-with-authn-token/env
+++ b/tests/test_cases/retrieve-variable-with-authn-token/env
@@ -1,0 +1,4 @@
+export CONJUR_CERT_FILE=./conjur.pem
+unset CONJUR_AUTHN_API_KEY
+unset CONJUR_AUTHN_LOGIN
+export CONJUR_AUTHN_TOKEN_FILE=./access_token

--- a/tests/test_cases/retrieve-variable-with-authn-token/playbook.yml
+++ b/tests/test_cases/retrieve-variable-with-authn-token/playbook.yml
@@ -1,0 +1,14 @@
+---
+- name: Retrieve Conjur variable with authn-token
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Clean artifact path
+      file:
+        state: absent
+        path: /conjur_secrets.txt
+
+    - name: Retrieve Conjur variable
+      vars:
+        super_secret_key: "{{lookup('conjur_variable', 'ansible/test-secret')}}"
+      shell: echo "{{super_secret_key}}" > /conjur_secrets.txt

--- a/tests/test_cases/retrieve-variable-with-authn-token/tests/test_default.py
+++ b/tests/test_cases/retrieve-variable-with-authn-token/tests/test_default.py
@@ -1,0 +1,13 @@
+import testinfra.utils.ansible_runner
+import os
+
+testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '_ansible_1']
+
+def test_retrieved_secret(host):
+    secrets_file = host.file('/conjur_secrets.txt')
+
+    assert secrets_file.exists
+
+    result = host.check_output("cat /conjur_secrets.txt", shell=True)
+
+    assert result == "test_secret_password"


### PR DESCRIPTION
### What does this PR do?
The PR add option to configure a path to authn file, like the authn-k8s.
It was manually tested locally with DAP v11.4.

### Related Issues
#23 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation