### PR TITLE
Add lookup plugin option (file_mode) to store secret in a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The [Conjur Ansible role](https://galaxy.ansible.com/cyberark/conjur-host-identity) has been
   migrated to this collection, where it will be maintained moving forward.
   [cyberark/ansible-conjur-host-identity#30](https://github.com/cyberark/ansible-conjur-host-identity/issues/30)
+- Add `file_mode` boolean option to store the secret as a temporary file in /dev/shm/ and return its path.
 
 ## [1.0.7] - 2020-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The [Conjur Ansible role](https://galaxy.ansible.com/cyberark/conjur-host-identity) has been
   migrated to this collection, where it will be maintained moving forward.
   [cyberark/ansible-conjur-host-identity#30](https://github.com/cyberark/ansible-conjur-host-identity/issues/30)
-- Add `file_mode` boolean option to store the secret as a temporary file in /dev/shm/ and return its path.
+- Add `as_file` boolean option to store the secret as a temporary file and returns its path.
+  [Cyberark Commons post #1070](https://discuss.cyberarkcommons.org/t/conjur-ansible-lookup-plugin-and-ssh-key-file/1070) 
 
 ## [1.0.7] - 2020-08-20
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ hosted in [Ansible Galaxy](https://galaxy.ansible.com/cyberark/conjur).
 * [Conjur Ansible Lookup Plugin](#conjur-ansible-lookup-plugin)
   + [Environment variables](#environment-variables)
   + [Role Variables](#role-variables-1)
-  + [Example Playbook](#example-playbook-1)
+  + [Examples](#examples)
+    - [Retrieve a secret in a Playbook](#retrieve-a-secret-in-a-playbook)
+    - [Retrieve a private key in an Inventory file](#retrieve-a-private-key-in-an-inventory-file)
 * [Contributing](#contributing)
 * [License](#license)
 
@@ -148,8 +150,10 @@ Conjur host, if they are present on the system running the lookup plugin.
 
 None.
 
-### Example Playbook
+### Examples
 
+#### Retrieve a secret in a Playbook
+ 
 ```yaml
 ---
 - hosts: localhost
@@ -158,6 +162,17 @@ None.
     debug:
       msg: "{{ lookup('cyberark.conjur.conjur_variable', '/path/to/secret') }}"
 ```
+
+#### Retrieve a private key in an Inventory file
+
+```yaml
+---
+ansible_host: <host>
+ansible_ssh_private_key_file: "{{ lookup('cyberark.conjur.conjur_variable', 'path/to/secret-id', as_file=True) }}"
+```
+
+**Note:** Using the `as_file=True` condition, the private key is stored in a temporary file and its path is written 
+in `ansible_ssh_private_key_file`.
 
 ## Contributing
 

--- a/tests/conjur_variable/policy/root.yml
+++ b/tests/conjur_variable/policy/root.yml
@@ -12,6 +12,7 @@
 
   - &variables
     - !variable test-secret
+    - !variable test-secret-in-file
     - !variable var with spaces
 
   - !permit

--- a/tests/conjur_variable/test.sh
+++ b/tests/conjur_variable/test.sh
@@ -66,6 +66,7 @@ function setup_conjur {
   docker-compose exec -T conjur_cli bash -c '
     conjur policy load root /policy/root.yml
     conjur variable values add ansible/test-secret test_secret_password
+    conjur variable values add ansible/test-secret-in-file test_secret_in_file_password
     conjur variable values add "ansible/var with spaces" var_with_spaces_secret_password
   '
 }

--- a/tests/conjur_variable/test_cases/retrieve-variable-into-file/env
+++ b/tests/conjur_variable/test_cases/retrieve-variable-into-file/env
@@ -1,0 +1,1 @@
+export CONJUR_CERT_FILE=./conjur.pem

--- a/tests/conjur_variable/test_cases/retrieve-variable-into-file/playbook.yml
+++ b/tests/conjur_variable/test_cases/retrieve-variable-into-file/playbook.yml
@@ -8,7 +8,7 @@
         state: absent
         path: /conjur_secret_path.txt
 
-    - name: Retrieve Conjur variable into file using file_mode option
+    - name: Retrieve Conjur variable into file using as_file option
       vars:
-        secret_path: "{{lookup('conjur_variable', 'ansible/test-secret-in-file', file_mode=True)}}"
+        secret_path: "{{lookup('conjur_variable', 'ansible/test-secret-in-file', as_file=True)}}"
       shell: echo "{{secret_path}}" > /conjur_secret_path.txt

--- a/tests/conjur_variable/test_cases/retrieve-variable-into-file/playbook.yml
+++ b/tests/conjur_variable/test_cases/retrieve-variable-into-file/playbook.yml
@@ -1,0 +1,14 @@
+---
+- name: Retrieve Conjur variable into file
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Clean artifact path
+      file:
+        state: absent
+        path: /conjur_secret_path.txt
+
+    - name: Retrieve Conjur variable into file using file_mode option
+      vars:
+        secret_path: "{{lookup('conjur_variable', 'ansible/test-secret-in-file', file_mode=True)}}"
+      shell: echo "{{secret_path}}" > /conjur_secret_path.txt

--- a/tests/conjur_variable/test_cases/retrieve-variable-into-file/playbook.yml
+++ b/tests/conjur_variable/test_cases/retrieve-variable-into-file/playbook.yml
@@ -11,4 +11,4 @@
     - name: Retrieve Conjur variable into file using as_file option
       vars:
         secret_path: "{{lookup('conjur_variable', 'ansible/test-secret-in-file', as_file=True)}}"
-      shell: echo "{{secret_path}}" > /conjur_secret_path.txt
+      shell: echo -n "{{secret_path}}" > /lookup_output.txt

--- a/tests/conjur_variable/test_cases/retrieve-variable-into-file/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-into-file/tests/test_default.py
@@ -1,0 +1,21 @@
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import os
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '_ansible_1']
+
+
+def test_retrieved_secret(host):
+    secret_path_file = host.file('/conjur_secret_path.txt')
+    assert secret_path_file.exists
+
+    secret_path = host.check_output("cat /conjur_secret_path.txt", shell=True)
+    secret_file = host.file(secret_path)
+    assert secret_file.exists
+    assert secret_file.mode == 0o600
+
+    secret = host.check_output("cat {0}".format(secret_path), shell=True)
+    assert secret == "test_secret_in_file_password"

--- a/tests/conjur_variable/test_cases/retrieve-variable-into-file/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-into-file/tests/test_default.py
@@ -9,13 +9,14 @@ testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '_ansible_1']
 
 
 def test_retrieved_secret(host):
-    secret_path_file = host.file('/conjur_secret_path.txt')
-    assert secret_path_file.exists
+    """
+    Verify that the as_file parameter makes the lookup plugin return the path to a temporary file
+    containing the secret.
+    """
+    lookup_output_file = host.file('/lookup_output.txt')
+    assert lookup_output_file.exists
 
-    secret_path = host.check_output("cat /conjur_secret_path.txt", shell=True)
-    secret_file = host.file(secret_path)
+    secret_file = host.file(lookup_output_file.content_string)
     assert secret_file.exists
     assert secret_file.mode == 0o600
-
-    secret = host.check_output("cat {0}".format(secret_path), shell=True)
-    assert secret == "test_secret_in_file_password"
+    assert secret_file.content_string == "test_secret_in_file_password"


### PR DESCRIPTION
### What does this PR do?

This PR offers a new option:  ~~file_mode~~ **as_file** (boolean) which adds the possibility to **store a secret as a file** in ~~/dev/shm~~ a temporary file instead of returning it directly. The lookup function instead returns the path of the file.

This feature addresses an issue with ansible_ssh_private_key_file which doesn't accept inline ssh keys. 
By adding this option, it is now possible to use the below lookup with ansible_ssh_private_key_file:
```yaml
ansible_ssh_private_key_file: "{​​{​​ lookup('cyberark.conjur.conjur_variable', 'path/to/secret-id', as_file=True) }​​}​​"
```
Without the need to handle temporary file creation in playbooks, it extends the current support of the below:
```yaml
ansible_password: "{​​{​​ lookup('cyberark.conjur.conjur_variable', 'path/to/secret-id') }​​}​​"
```
### What ticket does this PR close?

This PR addresses Issue #52 .
This PR also addresses the post in https://discuss.cyberarkcommons.org/t/conjur-ansible-lookup-plugin-and-ssh-key-file/1070

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation