### PR TITLE
Add galaxy importer validation to pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,16 +37,15 @@ pipeline {
     }
 
     stage('Build Release Artifacts') {
-      when {
-        anyOf {
-            branch 'master'
-            buildingTag()
-        }
-      }
-
       steps {
         sh './ci/build_release'
         archiveArtifacts 'cyberark-conjur-*.tar.gz'
+      }
+    }
+
+    stage('Validate Release Artifacts') {
+      steps {
+        sh './ci/validate_galaxy_importer'
       }
     }
 

--- a/ci/validate_galaxy_importer
+++ b/ci/validate_galaxy_importer
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+
+# Strip the 'v' from the Tag Name
+if [[ ! -z "${TAG_NAME:-}" ]]; then
+  TAG=${TAG_NAME//"v"}
+else
+  TAG="$(cat galaxy.yml | grep version | awk '{ print $2 }' | tr -d '"')"
+fi
+
+docker run --rm -t \
+  -v "$PWD:/runner/cyberark/" \
+  python:3.8-buster \
+  bash -c "
+    pip install galaxy-importer
+    python -m galaxy_importer.main /runner/cyberark/cyberark-conjur-${TAG}.tar.gz
+  "

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -3,8 +3,8 @@ name: "conjur"
 version: "1.1.0"
 readme: README.md
 authors:
-    - CyberArk Business Development (@cyberark-bizdev)
-    - CyberArk Community and Integrations Team (@cyberark/community-and-integrations-team)
+  - CyberArk Business Development (@cyberark-bizdev)
+  - Community Team (@cyberark/community-and-integrations-team)
 description: "This is a Collection of the CyberArk Conjur/DAP toolkit."
 license: "Apache-2.0"
 tags:


### PR DESCRIPTION
### What does this PR do?
In an effort to publish this integration to Ansible Hub for #56, we attempted
to upload our latest release and failed with the error:

> Invalid collection metadata. Each author in 'authors' list must not be greater
> than 64 characters

This commit fixes the error and adds a check to our pipeline to ensure that
we don't only discover galaxy-importer errors on publish.

This commit also updates the pipeline to always build the release, and not just
on tag or master branch builds, so that we can discover validation errors in
branch builds.


### What ticket does this PR close?
Related to #56 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation