### PR TITLE
Remove Python 3.7, 2.x

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -8,8 +8,6 @@
 #    - devel
 #
 #Python versions:
-#    - Python 2.7
-#    - Python 3.7
 #    - Python 3.8
 
 name: CI
@@ -36,8 +34,6 @@ jobs:
           - stable-2.10
           - devel
         python:
-          - 2.7
-          - 3.7
           - 3.8
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ Configure a remote node with a Conjur identity and Summon:
 - hosts: servers
   roles:
     - role: cyberark.conjur.conjur-host-identity
-      conjur_appliance_url: 'https://conjur.myorg.com',
-      conjur_account: 'myorg',
-      conjur_host_factory_token: "{{ lookup('env', 'HFTOKEN') }}",
+      conjur_appliance_url: 'https://conjur.myorg.com'
+      conjur_account: 'myorg'
+      conjur_host_factory_token: "{{ lookup('env', 'HFTOKEN') }}"
       conjur_host_name: "{{ inventory_hostname }}"
       conjur_ssl_certificate: "{{ lookup('file', '/path/to/conjur.pem') }}"
       conjur_validate_certs: yes

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash -ex
 
 # Test runner for Ansible Conjur Collection
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -41,7 +41,7 @@ function run_role_test {
 
 # Handles input to dictate wether all tests should be ran, or just one set
 function handle_input {
-    if [[ ! -z ${target} ]]; then
+    if [[ -n ${target} ]]; then
         for test_dir in "${test_directories[@]}"; do 
             if [[ ${target} == "${test_dir}" ]]; then
                 run_test ${target}
@@ -85,6 +85,11 @@ while getopts ahd: option; do
             ;;
         h) help
             ;;
+        * )
+          echo "$1 is not a valid option"
+          help
+          exit 1
+          ;;
     esac
 done
 

--- a/roles/conjur_host_identity/tests/Dockerfile
+++ b/roles/conjur_host_identity/tests/Dockerfile
@@ -1,24 +1,42 @@
-FROM ubuntu:18.04
+FROM ubuntu:latest
 
-RUN apt-get update && apt-get install -y \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    software-properties-common \
-    python3-pip
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN pip3 install pytest pytest-testinfra ansible && mkdir -p /conjurinc/
+WORKDIR /cyberark
 
+# install ansible
+RUN apt-get update && \
+    apt-get install -y ansible
+
+# install python 3
+RUN apt-get update && \
+    apt-get install -y python3-pip && \
+    pip3 install --upgrade pip==9.0.3
+
+# install ansible and its test tool
+RUN pip3 install ansible pytest-testinfra
+
+# install docker installation requirements
+RUN apt-get update && \
+    apt-get install -y apt-transport-https \
+                       ca-certificates \
+                       curl \
+                       software-properties-common
+
+# install docker
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 RUN add-apt-repository \
        "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
        $(lsb_release -cs) \
        stable"
-RUN apt-get update && apt-get -y install docker-ce
+
+RUN apt-get update && \
+    apt-get -y install docker-ce
+
+# NOTE: Everything above is copied from REPO_ROOT/tests/conjur_variable/Dockerfile. It defines a
+# standard container image for running ansible tests
+
+# install ruby
 RUN apt-get update && apt-get install -y gcc build-essential
 RUN apt-add-repository -y ppa:brightbox/ruby-ng && apt-get update && apt-get install -y ruby2.4 ruby2.4-dev
 RUN gem install conjur-cli
-
-WORKDIR /conjurinc/
-
-CMD ["/bin/sleep", "1d"]

--- a/roles/conjur_host_identity/tests/ansible.cfg
+++ b/roles/conjur_host_identity/tests/ansible.cfg
@@ -3,5 +3,5 @@ host_key_checking = False
 error_on_undefined_vars = True
 timeout = 60
 inventory = inventory.tmp
-roles_path = /conjurinc
+roles_path = /cyberark
 remote_tmp = /tmp

--- a/roles/conjur_host_identity/tests/docker-compose.yml
+++ b/roles/conjur_host_identity/tests/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    command: /bin/sleep 1d
     environment:
       CONJUR_APPLIANCE_URL: http://conjur:3000
       CONJUR_ACCOUNT: cucumber
@@ -11,9 +12,13 @@ services:
       CONJUR_AUTHN_API_KEY: ${ANSIBLE_CONJUR_AUTHN_API_KEY}
       CONJUR_CUSTOM_AUTHN_API_KEY: ${CUSTOM_CONJUR_AUTHN_API_KEY}
       COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
+      # NOTE: Explicitly setting the ANSIBLE_CONFIG envvar avoids Ansible ignoring
+      # the configuration because it is in a world-writable working directory,
+      # see https://docs.ansible.com/ansible/latest/reference_appendices/config.html#avoiding-security-risks-with-ansible-cfg-in-the-current-directory.
+      ANSIBLE_CONFIG: ./ansible.cfg
     volumes:
-      - ..:/conjurinc/cyberark.conjur.conjur-host-identity/
-      - .:/conjurinc/tests/
+      - ..:/cyberark/cyberark.conjur.conjur-host-identity/
+      - .:/cyberark/tests/
       - /var/run/docker.sock:/var/run/docker.sock
   pg:
     image: postgres:9.3

--- a/roles/conjur_host_identity/tests/inventory-playbook.yml
+++ b/roles/conjur_host_identity/tests/inventory-playbook.yml
@@ -3,4 +3,4 @@
   hosts: localhost
   tasks:
     - name: compile inventory template
-      template: src=inventory.j2 dest=/conjurinc/tests/inventory.tmp
+      template: src=inventory.j2 dest=/cyberark/tests/inventory.tmp

--- a/roles/conjur_host_identity/tests/test.sh
+++ b/roles/conjur_host_identity/tests/test.sh
@@ -22,7 +22,7 @@ declare ansible_cid=''
 
 function api_key_for {
   local role_id=$1
-  if [ ! -z "$role_id" ]
+  if [ -n "$role_id" ]
   then
     docker exec ${conjur_cid} rails r "print Credentials['${role_id}'].api_key"
   else
@@ -58,7 +58,7 @@ function run_test_cases {
 function run_test_case {
   echo "---- testing ${test_case} ----"
   local test_case=$1
-  if [ ! -z "$test_case" ]
+  if [ -n "$test_case" ]
   then
     docker exec "${ansible_cid}" env HFTOKEN="$(hf_token)" bash -c "
       cd tests

--- a/roles/conjur_host_identity/tests/test_cases/configure-conjur-identity/playbook.yml
+++ b/roles/conjur_host_identity/tests/test_cases/configure-conjur-identity/playbook.yml
@@ -2,7 +2,7 @@
 - name: Configuring conjur identity on remote hosts
   hosts: testapp
   roles:
-    - role: cyberark.conjur.conjur-host-identity
+    - role: "cyberark.conjur.conjur-host-identity"
       conjur_account: cucumber
       conjur_appliance_url: "https://conjur-proxy-nginx"
       conjur_host_factory_token: "{{lookup('env', 'HFTOKEN')}}"

--- a/roles/conjur_host_identity/tests/test_cases/configure-conjur-identity/tests/test_default.py
+++ b/roles/conjur_host_identity/tests/test_cases/configure-conjur-identity/tests/test_default.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    '/conjurinc/tests/inventory.tmp').get_hosts('testapp')
+    '/cyberark/tests/inventory.tmp').get_hosts('testapp')
 
 
 def test_hosts_file(host):

--- a/tests/conjur_variable/test.sh
+++ b/tests/conjur_variable/test.sh
@@ -90,7 +90,7 @@ function run_test_case {
   local test_case=$1
   echo "---- testing ${test_case} ----"
 
-  if [ ! -n "$test_case" ]; then
+  if [ -z "$test_case" ]; then
     echo ERROR: run_test called with no argument 1>&2
     exit 1
   fi

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,0 +1,10 @@
+Jenkinsfile shebang
+tests/conjur_variable/test.sh shebang
+tests/conjur_variable/policy/root.yml yamllint:unparsable-with-libyaml # File loaded by Conjur server, not via Python
+roles/conjur_host_identity/tests/test.sh shebang
+roles/conjur_host_identity/tests/policy/root.yml yamllint:unparsable-with-libyaml # File loaded by Conjur server, not via Python
+ci/build_release shebang
+ci/parse-changelog.sh shebang
+ci/publish_to_galaxy shebang
+ci/test.sh shebang
+secrets.yml yamllint:unparsable-with-libyaml # File loaded by Summon utility (in Jenkinsfile), not via Python


### PR DESCRIPTION
End support for Python 2.x, remove Python 3.7
Also merged in the changes from @doodlesbykumbi from PR #70 


DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained.
pip 21.0 will drop support for Python 2.7 in January 2021.
More details about Python 2 support in pip can be found at
https://pip.pypa.io/en/latest/development/release-process/#python-2-support

### Desired Outcome

CI tests should pass.

### Implemented Changes


### Connected Issue/Story

Resolves #68

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
