### PR TITLE
Fix conjur_host_identity tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ Configure a remote node with a Conjur identity and Summon:
 - hosts: servers
   roles:
     - role: cyberark.conjur.conjur-host-identity
-      conjur_appliance_url: 'https://conjur.myorg.com',
-      conjur_account: 'myorg',
-      conjur_host_factory_token: "{{ lookup('env', 'HFTOKEN') }}",
+      conjur_appliance_url: 'https://conjur.myorg.com'
+      conjur_account: 'myorg'
+      conjur_host_factory_token: "{{ lookup('env', 'HFTOKEN') }}"
       conjur_host_name: "{{ inventory_hostname }}"
       conjur_ssl_certificate: "{{ lookup('file', '/path/to/conjur.pem') }}"
       conjur_validate_certs: yes

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash -ex
 
 # Test runner for Ansible Conjur Collection
 

--- a/roles/conjur_host_identity/tests/Dockerfile
+++ b/roles/conjur_host_identity/tests/Dockerfile
@@ -1,24 +1,42 @@
-FROM ubuntu:18.04
+FROM ubuntu:latest
 
-RUN apt-get update && apt-get install -y \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    software-properties-common \
-    python3-pip
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN pip3 install pytest pytest-testinfra ansible && mkdir -p /conjurinc/
+WORKDIR /cyberark
 
+# install ansible
+RUN apt-get update && \
+    apt-get install -y ansible
+
+# install python 3
+RUN apt-get update && \
+    apt-get install -y python3-pip && \
+    pip3 install --upgrade pip==9.0.3
+
+# install ansible and its test tool
+RUN pip3 install ansible pytest-testinfra
+
+# install docker installation requirements
+RUN apt-get update && \
+    apt-get install -y apt-transport-https \
+                       ca-certificates \
+                       curl \
+                       software-properties-common
+
+# install docker
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 RUN add-apt-repository \
        "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
        $(lsb_release -cs) \
        stable"
-RUN apt-get update && apt-get -y install docker-ce
+
+RUN apt-get update && \
+    apt-get -y install docker-ce
+
+# NOTE: Everything above is copied from REPO_ROOT/tests/conjur_variable/Dockerfile. It defines a
+# standard container image for running ansible tests
+
+# install ruby
 RUN apt-get update && apt-get install -y gcc build-essential
 RUN apt-add-repository -y ppa:brightbox/ruby-ng && apt-get update && apt-get install -y ruby2.4 ruby2.4-dev
 RUN gem install conjur-cli
-
-WORKDIR /conjurinc/
-
-CMD ["/bin/sleep", "1d"]

--- a/roles/conjur_host_identity/tests/ansible.cfg
+++ b/roles/conjur_host_identity/tests/ansible.cfg
@@ -3,5 +3,5 @@ host_key_checking = False
 error_on_undefined_vars = True
 timeout = 60
 inventory = inventory.tmp
-roles_path = /conjurinc
+roles_path = /cyberark
 remote_tmp = /tmp

--- a/roles/conjur_host_identity/tests/docker-compose.yml
+++ b/roles/conjur_host_identity/tests/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    command: /bin/sleep 1d
     environment:
       CONJUR_APPLIANCE_URL: http://conjur:3000
       CONJUR_ACCOUNT: cucumber
@@ -11,9 +12,13 @@ services:
       CONJUR_AUTHN_API_KEY: ${ANSIBLE_CONJUR_AUTHN_API_KEY}
       CONJUR_CUSTOM_AUTHN_API_KEY: ${CUSTOM_CONJUR_AUTHN_API_KEY}
       COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
+      # NOTE: Explicitly setting the ANSIBLE_CONFIG envvar avoids Ansible ignoring
+      # the configuration because it is in a world-writable working directory,
+      # see https://docs.ansible.com/ansible/latest/reference_appendices/config.html#avoiding-security-risks-with-ansible-cfg-in-the-current-directory.
+      ANSIBLE_CONFIG: ./ansible.cfg
     volumes:
-      - ..:/conjurinc/cyberark.conjur.conjur-host-identity/
-      - .:/conjurinc/tests/
+      - ..:/cyberark/cyberark.conjur.conjur-host-identity/
+      - .:/cyberark/tests/
       - /var/run/docker.sock:/var/run/docker.sock
   pg:
     image: postgres:9.3

--- a/roles/conjur_host_identity/tests/inventory-playbook.yml
+++ b/roles/conjur_host_identity/tests/inventory-playbook.yml
@@ -3,4 +3,4 @@
   hosts: localhost
   tasks:
     - name: compile inventory template
-      template: src=inventory.j2 dest=/conjurinc/tests/inventory.tmp
+      template: src=inventory.j2 dest=/cyberark/tests/inventory.tmp

--- a/roles/conjur_host_identity/tests/test_cases/configure-conjur-identity/playbook.yml
+++ b/roles/conjur_host_identity/tests/test_cases/configure-conjur-identity/playbook.yml
@@ -2,7 +2,7 @@
 - name: Configuring conjur identity on remote hosts
   hosts: testapp
   roles:
-    - role: cyberark.conjur.conjur-host-identity
+    - role: "cyberark.conjur.conjur-host-identity"
       conjur_account: cucumber
       conjur_appliance_url: "https://conjur-proxy-nginx"
       conjur_host_factory_token: "{{lookup('env', 'HFTOKEN')}}"

--- a/roles/conjur_host_identity/tests/test_cases/configure-conjur-identity/tests/test_default.py
+++ b/roles/conjur_host_identity/tests/test_cases/configure-conjur-identity/tests/test_default.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    '/conjurinc/tests/inventory.tmp').get_hosts('testapp')
+    '/cyberark/tests/inventory.tmp').get_hosts('testapp')
 
 
 def test_hosts_file(host):


### PR DESCRIPTION


### Desired Outcome

Fix broken CI

### Implemented Changes

1. Standardise on the base container image for running ansible tests. Change image used by `conjur_host_identity` to match `conjur_variable`.
2.  Explicitly set the ANSIBLE_CONFIG envvar to avoid Ansible ignoring the configuration because it is in a world-writable working directory, see https://docs.ansible.com/ansible/latest/reference_appendices/config.html#avoiding-security-risks-with-ansible-cfg-in-the-current-directory.

### Connected Issue/Story

Resolves N/A

CyberArk internal issue link: [insert issue ID]()

### Definition of Done

N/A


#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
