### PR TITLE
Bugfix: Mount role directory into Ansible container

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -32,6 +32,8 @@ jobs:
           # Testing against `devel` may fail as new tests are added.
           - stable-2.9
           - stable-2.10
+          - stable-2.11
+          - stable-2.12
           - devel
         python:
           - 3.8

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -4,14 +4,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /cyberark
 
-# install ansible
-RUN apt-get update && \
-    apt-get install -y ansible
-
 # install python 3
 RUN apt-get update && \
     apt-get install -y python3-pip && \
-    pip3 install --upgrade pip==9.0.3
+    pip3 install --upgrade pip
 
 # install ansible and its test tool
 RUN pip3 install ansible pytest-testinfra

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -17,9 +17,10 @@ services:
       # see https://docs.ansible.com/ansible/latest/reference_appendices/config.html#avoiding-security-risks-with-ansible-cfg-in-the-current-directory.
       ANSIBLE_CONFIG: ./ansible.cfg
     volumes:
-      - ~/ansible-conjur-collection/roles/conjur_host_identity:/cyberark/cyberark.conjur.conjur-host-identity/
+      - ../roles/conjur_host_identity:/cyberark/cyberark.conjur.conjur-host-identity/
       - .:/cyberark/dev/
       - /var/run/docker.sock:/var/run/docker.sock
+
   pg:
     image: postgres:9.3
 

--- a/plugins/lookup/conjur_variable.py
+++ b/plugins/lookup/conjur_variable.py
@@ -9,12 +9,11 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'community'}
 
 DOCUMENTATION = """
-    lookup: conjur_variable
-    version_added: "2.5"
+    name: conjur_variable
+    version_added: "1.0.2"
     short_description: Fetch credentials from CyberArk Conjur.
     author:
       - CyberArk BizDev (@cyberark-bizdev)
-      - CyberArk Community and Integrations Team (@cyberark/community-and-integrations-team)
     description:
       Retrieves credentials from Conjur using the controlling host's Conjur identity
       or environment variables.

--- a/roles/conjur_host_identity/tests/Dockerfile
+++ b/roles/conjur_host_identity/tests/Dockerfile
@@ -4,14 +4,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /cyberark
 
-# install ansible
-RUN apt-get update && \
-    apt-get install -y ansible
-
 # install python 3
 RUN apt-get update && \
     apt-get install -y python3-pip && \
-    pip3 install --upgrade pip==9.0.3
+    pip3 install --upgrade pip
 
 # install ansible and its test tool
 RUN pip3 install ansible pytest-testinfra

--- a/tests/conjur_variable/Dockerfile
+++ b/tests/conjur_variable/Dockerfile
@@ -4,14 +4,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /cyberark
 
-# install ansible
-RUN apt-get update && \
-    apt-get install -y ansible
-
 # install python 3
 RUN apt-get update && \
     apt-get install -y python3-pip && \
-    pip3 install --upgrade pip==9.0.3
+    pip3 install --upgrade pip
 
 # install ansible and its test tool
 RUN pip3 install ansible pytest-testinfra

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,0 +1,13 @@
+Jenkinsfile shebang
+dev/start.sh shebang
+tests/conjur_variable/test.sh shebang
+tests/conjur_variable/policy/root.yml yamllint:unparsable-with-libyaml # File loaded by Conjur server, not via Python
+roles/conjur_host_identity/tests/test.sh shebang
+roles/conjur_host_identity/tests/policy/root.yml yamllint:unparsable-with-libyaml # File loaded by Conjur server, not via Python
+ci/build_release shebang
+ci/parse-changelog.sh shebang
+ci/publish_to_galaxy shebang
+ci/test.sh shebang
+secrets.yml yamllint:unparsable-with-libyaml # File loaded by Summon utility (in Jenkinsfile), not via Python
+dev/policy/root.yml yamllint:unparsable-with-libyaml
+plugins/lookup/conjur_variable.py validate-modules:version-added-must-be-major-or-minor # Lookup plugin added in v1.0.2


### PR DESCRIPTION
### Desired Outcome

In its current state, the development environment was silently failing during setup.
The `conjur-host-identity` role was incorrectly mounted into the Ansible control node container, so using it to set up Conjur identities on the managed nodes silently failed.

### Implemented Changes

Addressed some other bugs while I was in the repo.
- The `conjur-host-identity` role directory is mounted into the Ansible control node container for the development environment.
- Add collection sanity test against Ansible 2.11 and 2.12.
- Add `tests/sanity/ignore-2.14.txt`.
- Remove @cyberark/community-and-integrations-team from `conjur_variable` plugin authors. Not only does [Ansible's module validation only allow GitHub usernames for individual contributors](https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py#L28-L35), but [teams can only be viewed or mentioned by organization members](https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams#team-visibility). The C&I team username isn't helpful for users outside the CyberArk org.
- Update `conjur_variable` documentation for updates to Ansible `devel` branch.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
