### PR TITLE
Add negative test case for Conjur Role

### DIFF
--- a/roles/conjur_host_identity/tests/test_app_ubuntu/Dockerfile
+++ b/roles/conjur_host_identity/tests/test_app_ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 # Install Python so Ansible can run against node
 RUN apt-get update -y && apt-get install -y python3-minimal

--- a/roles/conjur_host_identity/tests/test_cases/misconfig-conjur-identity/playbook.yml
+++ b/roles/conjur_host_identity/tests/test_cases/misconfig-conjur-identity/playbook.yml
@@ -1,0 +1,22 @@
+---
+- name: Configuring Conjur identity on remote hosts fails when missing required variable
+  hosts: testapp
+  tasks:
+    - name: Attempt to configure Conjur identity
+      block:
+        - import_role:
+            name: "cyberark.conjur.conjur-host-identity"
+          vars:
+            conjur_account: cucumber
+            # conjur_appliance_url: "https://conjur-proxy-nginx"
+            conjur_host_factory_token: "{{lookup('env', 'HFTOKEN')}}"
+            conjur_host_name: "conjur_{{ ansible_hostname }}"
+            conjur_ssl_certificate: "{{lookup('file', '../../conjur.pem')}}"
+            conjur_validate_certs: yes
+      rescue:
+        - name: Confirm Role setup fails
+          assert:
+            that: ansible_failed_result.failed == true
+        - name: Confirm error message
+          assert:
+            that: ansible_failed_result.msg == "'conjur_appliance_url' is undefined"


### PR DESCRIPTION
### Desired Outcome

For conjur_host_identity role , there should be expansion to cover failing cases, where using the role fails due to some sort of misconfiguration.

### Implemented Changes

Added `roles/conjur_host_identity/tests/test_cases/misconfig-conjur-identity/`.
### Connected Issue/Story

CyberArk internal issue link: [ONYX-15262](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-15262)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [X] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
