### PR TITLE
Validate variable paths given to Lookup plugin

### DIFF
--- a/plugins/lookup/conjur_variable.py
+++ b/plugins/lookup/conjur_variable.py
@@ -268,6 +268,11 @@ def _store_secret_in_file(value):
 class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
+        if terms == []:
+            raise AnsibleError("Invalid secret path: no secret path provided.")
+        elif not terms[0] or terms[0].isspace():
+            raise AnsibleError("Invalid secret path: empty secret path not accepted.")
+
         self.set_options(direct=kwargs)
         validate_certs = self.get_option('validate_certs')
         conf_file = self.get_option('config_file')


### PR DESCRIPTION
### Desired Outcome

The conjur_variable lookup should validate the provided Conjur variable path. Error messages regarding invalid secret path inputs should be more accurate and descriptive. 

### Implemented Changes

Code changes are in conjur_variable plugin  to cover all Conjur variable path issues .

### Connected Issue/Story

CyberArk internal issue link: [ONYX-15265](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-15265)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
