### PR TITLE
Fix tests on docker-compose v2

### DIFF
--- a/roles/conjur_host_identity/tests/inventory-playbook-v2.yml
+++ b/roles/conjur_host_identity/tests/inventory-playbook-v2.yml
@@ -1,0 +1,6 @@
+---
+- name: Compile inventory template locally
+  hosts: localhost
+  tasks:
+    - name: compile inventory template
+      template: src=inventory-v2.j2 dest=/cyberark/tests/inventory.tmp

--- a/roles/conjur_host_identity/tests/inventory-v2.j2
+++ b/roles/conjur_host_identity/tests/inventory-v2.j2
@@ -1,0 +1,6 @@
+[testapp]
+{{ lookup('env','COMPOSE_PROJECT_NAME') }}-test_app_ubuntu-[1:2] ansible_connection=docker
+{{ lookup('env','COMPOSE_PROJECT_NAME') }}-test_app_centos-[1:2] ansible_connection=docker
+
+[ansible]
+{{ lookup('env','COMPOSE_PROJECT_NAME') }}-ansible-1 ansible_connection=docker

--- a/roles/conjur_host_identity/tests/test.sh
+++ b/roles/conjur_host_identity/tests/test.sh
@@ -100,11 +100,18 @@ function fetch_ssl_cert {
 }
 
 function generate_inventory {
+  # Use a different inventory file for docker-compose v1 and v2 or later
+  playbook_file="inventory-playbook-v2.yml"
+  compose_ver=$(docker-compose version --short)
+  if [[ $compose_ver == "1"* ]]; then
+    playbook_file="inventory-playbook.yml"
+  fi
+
   # uses .j2 template to generate inventory prepended with COMPOSE_PROJECT_NAME
-  docker-compose exec -T ansible bash -ec '
+  docker-compose exec -T ansible bash -ec "
     cd tests
-    ansible-playbook inventory-playbook.yml
-  '
+    ansible-playbook $playbook_file
+  "
 }
 
 function main() {

--- a/tests/conjur_variable/docker-compose.yml
+++ b/tests/conjur_variable/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   ansible:
+    container_name: ${COMPOSE_PROJECT_NAME}-ansible
     build:
       context: .
       dockerfile: Dockerfile

--- a/tests/conjur_variable/test_cases/retrieve-variable-bad-cert-path/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-bad-cert-path/tests/test_default.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import os
 import testinfra.utils.ansible_runner
 
-testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '_ansible_1']
+testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 
 
 def test_retrieval_failed(host):

--- a/tests/conjur_variable/test_cases/retrieve-variable-bad-certs/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-bad-certs/tests/test_default.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import os
 import testinfra.utils.ansible_runner
 
-testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '_ansible_1']
+testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 
 
 def test_retrieval_failed(host):

--- a/tests/conjur_variable/test_cases/retrieve-variable-disable-verify-certs/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-disable-verify-certs/tests/test_default.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import os
 import testinfra.utils.ansible_runner
 
-testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '_ansible_1']
+testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 
 
 def test_retrieved_secret(host):

--- a/tests/conjur_variable/test_cases/retrieve-variable-into-file/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-into-file/tests/test_default.py
@@ -5,7 +5,7 @@ __metaclass__ = type
 import os
 import testinfra.utils.ansible_runner
 
-testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '_ansible_1']
+testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 
 
 def test_retrieved_secret(host):

--- a/tests/conjur_variable/test_cases/retrieve-variable-no-cert-provided/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-no-cert-provided/tests/test_default.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import os
 import testinfra.utils.ansible_runner
 
-testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '_ansible_1']
+testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 
 
 def test_retrieval_failed(host):

--- a/tests/conjur_variable/test_cases/retrieve-variable-with-authn-token-bad-cert/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-with-authn-token-bad-cert/tests/test_default.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import os
 import testinfra.utils.ansible_runner
 
-testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '_ansible_1']
+testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 
 
 def test_retrieve_secret_failed(host):

--- a/tests/conjur_variable/test_cases/retrieve-variable-with-authn-token/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-with-authn-token/tests/test_default.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import os
 import testinfra.utils.ansible_runner
 
-testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '_ansible_1']
+testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 
 
 def test_retrieved_secret(host):

--- a/tests/conjur_variable/test_cases/retrieve-variable-with-spaces-secret/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-with-spaces-secret/tests/test_default.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import os
 import testinfra.utils.ansible_runner
 
-testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '_ansible_1']
+testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 
 
 def test_retrieved_secret(host):

--- a/tests/conjur_variable/test_cases/retrieve-variable/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable/tests/test_default.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import os
 import testinfra.utils.ansible_runner
 
-testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '_ansible_1']
+testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 
 
 def test_retrieved_secret(host):


### PR DESCRIPTION
### Desired Outcome

Tests should pass both with docker-compose v1 (as on Jenkins) and v2 (as on local machines).

Docker Compose v2 changes the default naming convention for containers, from '_' to '-'. To support both v1 and v2, explicitly set the container_name in docker-compose.yml for the conjur_variable tests.
For the roles/conjur_host_identity tests we can't use container_name because we use scaling, and docker-compose doesn't support specifying a container_name when requiring multiple instances of a container. Instead we use different inventory.j2 template files for the different docker-compose versions.

### Implemented Changes

- Conjur_variable tests: Updated docker-compose.yml to explicitly set container_name
- Conjur_variable tests: Updated tests to use the new container name
- Roles/conjur_host_identity tests: Use separate inventory.j2 files for different docker-compose versions

### Connected Issue/Story

N/A

### Definition of Done

- [x] Tests pass on docker-compose v2 locally
- [x] Tests pass on docker-compose v1 on Jenkins

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
