### PR TITLE
Report Lookup plugin unit test coverage to Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,14 @@ pipeline {
 
         stage("Run conjur_variable unit tests") {
           steps {
-            sh './dev/test_unit.sh'
+            sh './dev/test_unit.sh -r'
+            publishHTML (target : [allowMissing: false,
+              alwaysLinkToLastBuild: false,
+              keepAll: true,
+              reportDir: 'tests/output/reports/coverage=units/',
+              reportFiles: 'index.html',
+              reportName: 'Ansible Coverage Report',
+              reportTitles: 'Conjur Ansible Collection report'])
           }
         }
       }

--- a/dev/test_unit.sh
+++ b/dev/test_unit.sh
@@ -28,11 +28,11 @@ while getopts 'a:p:r' flag; do
    esac
 done
 
-test_cmd="ansible-test units --python $python_version"
+test_cmd="ansible-test units -v --python $python_version"
 if [[ "$gen_report" == "true" ]]; then
   test_cmd="ansible-test coverage erase;
     $test_cmd --coverage;
-    ansible-test coverage html -v --requirements --group-by command --group-by version;
+    ansible-test coverage html --requirements --group-by command;
   "
 fi
 

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -4,6 +4,7 @@ pytest-mock
 pytest-xdist
 pytest-forked
 pyyaml  # required by the collection loader (only needed for collections)
+coverage==4.5.4
 
 bcrypt ; python_version >= '3.8'  # controller only
 passlib ; python_version >= '3.8'  # controller only


### PR DESCRIPTION
### Desired Outcome

Generate test coverage reporting in CI, to ensure that the repo is sufficiently unit tested.

### Implemented Changes

Jenkins file and test_unit script file

### Connected Issue/Story

CyberArk internal issue link: [ONYX-15264](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-15264)

### Definition of Done
Implement code coverage reporting in CI, either with ccCoverage or ansible-test
Investigate whether the ccCoverage Jenkins plugin can be used for the Collection repo

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
