### PR TITLE
Jenkins and dev environment bugfixes

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/dev/playbooks/inventory-setup/inventory-playbook-v2.yml
+++ b/dev/playbooks/inventory-setup/inventory-playbook-v2.yml
@@ -1,0 +1,6 @@
+---
+- name: Compile inventory template locally
+  hosts: localhost
+  tasks:
+    - name: compile inventory template
+      template: src=inventory-v2.j2 dest=/cyberark/tests/inventory.tmp

--- a/dev/playbooks/inventory-setup/inventory-v2.j2
+++ b/dev/playbooks/inventory-setup/inventory-v2.j2
@@ -1,0 +1,6 @@
+[testapp]
+{{ lookup('env','COMPOSE_PROJECT_NAME') }}-test_app_ubuntu-[1:2] ansible_connection=docker
+{{ lookup('env','COMPOSE_PROJECT_NAME') }}-test_app_centos-[1:2] ansible_connection=docker
+
+[ansible]
+{{ lookup('env','COMPOSE_PROJECT_NAME') }}-ansible-1 ansible_connection=docker

--- a/dev/playbooks/inventory-setup/inventory.j2
+++ b/dev/playbooks/inventory-setup/inventory.j2
@@ -1,6 +1,6 @@
 [testapp]
-{{ lookup('env','COMPOSE_PROJECT_NAME') }}-test_app_ubuntu-[1:2] ansible_connection=docker
-{{ lookup('env','COMPOSE_PROJECT_NAME') }}-test_app_centos-[1:2] ansible_connection=docker
+{{ lookup('env','COMPOSE_PROJECT_NAME') }}_test_app_ubuntu_[1:2] ansible_connection=docker
+{{ lookup('env','COMPOSE_PROJECT_NAME') }}_test_app_centos_[1:2] ansible_connection=docker
 
 [ansible]
-{{ lookup('env','COMPOSE_PROJECT_NAME') }}-ansible-1 ansible_connection=docker
+{{ lookup('env','COMPOSE_PROJECT_NAME') }}_ansible_1 ansible_connection=docker

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -67,11 +67,18 @@ function fetch_ssl_cert {
 }
 
 function generate_inventory {
+  # Use a different inventory file for docker-compose v1 and v2 or later
+  playbook_file="inventory-playbook-v2.yml"
+  compose_ver=$(docker-compose version --short)
+  if [[ $compose_ver == "1"* ]]; then
+    playbook_file="inventory-playbook.yml"
+  fi
+
   # uses .j2 template to generate inventory prepended with COMPOSE_PROJECT_NAME
-  docker-compose exec -T ansible bash -ec '
+  docker-compose exec -T ansible bash -ec "
     cd dev
-    ansible-playbook playbooks/inventory-setup/inventory-playbook.yml
-  '
+    ansible-playbook playbooks/inventory-setup/$playbook_file
+  "
 }
 
 function clean {

--- a/dev/test_app_centos/Dockerfile
+++ b/dev/test_app_centos/Dockerfile
@@ -1,4 +1,4 @@
 FROM centos:7
 
 # Install Python so Ansible can run against node
-RUN yum update -y && yum install -y epel-release && yum install -y python3 jq
+RUN yum update -y && yum install -y python3

--- a/dev/test_app_ubuntu/Dockerfile
+++ b/dev/test_app_ubuntu/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:20.04
 
 # Install Python so Ansible can run against node
-RUN apt-get update -y && apt-get install -y python3-minimal jq
+RUN apt-get update -y && apt-get install -y python3-minimal
+

--- a/roles/conjur_host_identity/tests/Dockerfile
+++ b/roles/conjur_host_identity/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/tests/conjur_variable/Dockerfile
+++ b/tests/conjur_variable/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
### Desired Outcome

Jenkins builds were failing with the following logs when building the Ansible service:
```
E: Problem executing scripts APT::Update::Post-Invoke 'rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true'
E: Sub-process returned an error code
```

This error occurs when running `apt-get` commands in Ubuntu 22.04 in Docker <= 20.10.9.
These Dockerfiles have been pinned to Ubuntu 20.04.

### Implemented Changes

- Dev env scripts now support `docker-compose` v1 and v2.
- Ubuntu-based Dockerfiles are pinned to 20.04.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-19624](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-19624)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
