### PR TITLE
Test collection against Ansible versions 5 and 6 in Jenkins

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -3,7 +3,6 @@
 # run across the following matrices:
 #
 #Ansible versions:
-#    - stable-2.9
 #    - stable-2.10
 #    - stable-2.11
 #    - stable-2.12

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -14,11 +14,14 @@ target=""
 # Flags to be applied to testing scripts
 flags=""
 
+declare -x ANSIBLE_VERSION="${ANSIBLE_VERSION:-6}"
+
 # Print usage instructions
 function help {
     echo "Test runner for Ansible Conjur Collection"
 
     echo "-a        Run all test files in default test directories"
+    echo "-v <ver>  Run tests against the given Ansible major version"
     echo "-d <arg>  Run test file in given directory. Valid options are: ${test_directories[*]} all"
     echo "-e        Run tests against Conjur Enterprise. Default: Conjur Open Source"
     echo "          This option is currently only available when testing against the conjur_variable plugin"
@@ -81,16 +84,18 @@ if [[ $# -eq 0 ]] ; then
     help
 fi
 
-while getopts aehd: option; do
-  case "$option" in
+while getopts ad:ehv: option; do
+    case "$option" in
         a) handle_input
+            ;;
+        d) target=${OPTARG}
+           handle_input
             ;;
         e) flags="-e"
             ;;
         h) help
             ;;
-        d) target=${OPTARG}
-            handle_input
+        v) ANSIBLE_VERSION="${OPTARG}"
             ;;
         * )
           echo "$1 is not a valid option"

--- a/roles/conjur_host_identity/tests/Dockerfile
+++ b/roles/conjur_host_identity/tests/Dockerfile
@@ -9,8 +9,9 @@ RUN apt-get update && \
     apt-get install -y python3-pip && \
     pip3 install --upgrade pip
 
+ARG ANSIBLE_VERSION
 # install ansible and its test tool
-RUN pip3 install ansible pytest-testinfra
+RUN pip3 install ansible==${ANSIBLE_VERSION}.* pytest-testinfra
 
 # install docker installation requirements
 RUN apt-get update && \

--- a/roles/conjur_host_identity/tests/docker-compose.yml
+++ b/roles/conjur_host_identity/tests/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        ANSIBLE_VERSION: ${ANSIBLE_VERSION}
     command: /bin/sleep 1d
     environment:
       CONJUR_APPLIANCE_URL: ${CONJUR_APPLIANCE_URL}

--- a/roles/conjur_host_identity/tests/test.sh
+++ b/roles/conjur_host_identity/tests/test.sh
@@ -10,6 +10,7 @@ declare -x ANSIBLE_PROJECT=''
 declare -x ANSIBLE_CONJUR_AUTHN_API_KEY=''
 declare -x CLI_CONJUR_AUTHN_API_KEY=''
 declare -x DOCKER_NETWORK="default"
+declare -x ANSIBLE_VERSION="${ANSIBLE_VERSION:-6}"
 
 declare cli_cid=''
 declare ansible_cid=''

--- a/tests/conjur_variable/Dockerfile
+++ b/tests/conjur_variable/Dockerfile
@@ -9,8 +9,9 @@ RUN apt-get update && \
     apt-get install -y python3-pip && \
     pip3 install --upgrade pip
 
+ARG ANSIBLE_VERSION
 # install ansible and its test tool
-RUN pip3 install ansible pytest-testinfra
+RUN pip3 install ansible==${ANSIBLE_VERSION}.* pytest-testinfra
 
 # install docker installation requirements
 RUN apt-get update && \

--- a/tests/conjur_variable/docker-compose.yml
+++ b/tests/conjur_variable/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+       ANSIBLE_VERSION: ${ANSIBLE_VERSION}
     entrypoint: sleep
     command: infinity
     environment:

--- a/tests/conjur_variable/test.sh
+++ b/tests/conjur_variable/test.sh
@@ -10,6 +10,7 @@ declare -x ANSIBLE_PROJECT=''
 declare -x ANSIBLE_MASTER_AUTHN_API_KEY=''
 declare -x CONJUR_ADMIN_AUTHN_API_KEY=''
 declare -x DOCKER_NETWORK="default"
+declare -x ANSIBLE_VERSION="${ANSIBLE_VERSION:-6}"
 
 ANSIBLE_PROJECT=$(echo "${BUILD_TAG:-ansible-plugin-testing}-conjur-variable" | sed -e 's/[^[:alnum:]]//g' | tr '[:upper:]' '[:lower:]')
 


### PR DESCRIPTION
### Desired Outcome

For an Ansible Collection to be certified by RedHat, it needs to be tested against at least two versions of Ansible Core.

### Implemented Changes

This PR allows for the tests in the Collection to be configured to run against a particular Ansible major version, and updates the Jenkinsfile to run tests against Ansible 5 and 6, which corresponds to Ansible Core 2.12 and 2.13, respectively.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-24058](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-24058)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
