### PR TITLE
Build fix

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -30,6 +30,10 @@ jobs:
   sanity:
     name: Sanity (${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:
+      # fail-fast means one failing matrix case will cancel all other
+      # still-incomplete cases. As tests against Ansible's devel branch are
+      # unstable, this is disabled.
+      fail-fast: false
       matrix:
         ansible:
           - stable-2.13
@@ -83,6 +87,10 @@ jobs:
   units:
     name: Units (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:
+      # fail-fast means one failing matrix case will cancel all other
+      # still-incomplete cases. As tests against Ansible's devel branch are
+      # unstable, this is disabled.
+      fail-fast: false
       matrix:
         ansible:
           - stable-2.13

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -2,14 +2,17 @@
 # on the Conjur Ansible Collection. The Ansible collection sanity tests are
 # run across the following matrices:
 #
-#Ansible versions:
-#    - stable-2.10
-#    - stable-2.11
-#    - stable-2.12
-#    - devel
+# Ansible versions:
+# - stable-2.13
+# - stable-2.14
+# - stable-2.15
+# - devel
 #
-#Python versions:
-#    - Python 3.9
+# Python versions:
+# - 3.8 (2.13)
+# - 3.9 (2.13, 2.14, 2.15)
+# - 3.10
+# - 3.11 (2.14, 2.15)
 
 name: CI
 on:
@@ -29,14 +32,22 @@ jobs:
     strategy:
       matrix:
         ansible:
-          # It's important that Sanity is tested against all stable-X.Y branches
-          # Testing against `devel` may fail as new tests are added.
-          - stable-2.10
-          - stable-2.11
-          - stable-2.12
-          - devel
+          - stable-2.13
+          - stable-2.14
+          - stable-2.15
         python:
-          - 3.9
+          - '3.9'
+          - '3.10'
+        include:
+          - ansible: stable-2.13
+            python: '3.8'
+          - ansible: stable-2.14
+            python: '3.11'
+          - ansible: stable-2.15
+            python: '3.11'
+          - ansible: devel
+            python: '3.10'
+
     runs-on: ubuntu-latest
     steps:
 
@@ -59,13 +70,14 @@ jobs:
 
       # run ansible-test sanity inside of Docker.
       # The docker container has all the pinned dependencies that are required.
-      # Explicity specify the version of Python we want to test
+      # Explicitly specify the version of Python we want to test
       - name: Run sanity tests
         run: ansible-test sanity --docker -v --color --python ${{ matrix.python }}
         working-directory: ./ansible_collections/cyberark/conjur
 
+###
 # Unit tests (OPTIONAL)
-
+#
 # https://docs.ansible.com/ansible/latest/dev_guide/testing_units.html
 
   units:
@@ -73,12 +85,21 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.10
-          - stable-2.11
-          - stable-2.12
-          - devel
+          - stable-2.13
+          - stable-2.14
+          - stable-2.15
         python:
-          - 3.9
+          - '3.9'
+          - '3.10'
+        include:
+          - ansible: stable-2.13
+            python: '3.8'
+          - ansible: stable-2.14
+            python: '3.11'
+          - ansible: stable-2.15
+            python: '3.11'
+          - ansible: devel
+            python: '3.10'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,10 @@ pipeline {
     buildDiscarder(logRotator(numToKeepStr: '30'))
   }
 
+  triggers {
+    cron(getDailyCronString())
+  }
+
   stages {
     stage('Validate') {
       parallel {

--- a/plugins/lookup/conjur_variable.py
+++ b/plugins/lookup/conjur_variable.py
@@ -92,7 +92,7 @@ from ansible.plugins.lookup import LookupBase
 from base64 import b64encode
 from netrc import netrc
 from os import environ
-from time import time, sleep
+from time import sleep
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.module_utils.urls import urllib_error
 from stat import S_IRUSR, S_IWUSR
@@ -101,7 +101,6 @@ import yaml
 
 from ansible.module_utils.urls import open_url
 from ansible.utils.display import Display
-import ssl
 
 display = Display()
 

--- a/roles/conjur_host_identity/tests/test.sh
+++ b/roles/conjur_host_identity/tests/test.sh
@@ -35,6 +35,10 @@ function clean {
     rm -rf conjur-intro
   fi
 
+  if [[ -n "$cli_cid" ]]; then
+    docker rm -f "$cli_cid"
+  fi
+
   COMPOSE_PROJECT_NAME="${ANSIBLE_PROJECT}"
   docker-compose down -v
   rm -rf inventory.tmp \

--- a/tests/conjur_variable/test.sh
+++ b/tests/conjur_variable/test.sh
@@ -33,6 +33,10 @@ function cleanup {
     rm -rf conjur-intro
   fi
 
+  if [[ -n "$cli_cid" ]]; then
+    docker rm -f "$cli_cid"
+  fi
+
   COMPOSE_PROJECT_NAME="${ANSIBLE_PROJECT}"
   docker-compose down -v
   rm -f conjur.pem \

--- a/tests/conjur_variable/test_cases/retrieve-variable-bad-cert-path/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-bad-cert-path/tests/test_default.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import testinfra.utils.ansible_runner
 
 testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 

--- a/tests/conjur_variable/test_cases/retrieve-variable-bad-certs/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-bad-certs/tests/test_default.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import testinfra.utils.ansible_runner
 
 testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 

--- a/tests/conjur_variable/test_cases/retrieve-variable-disable-verify-certs/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-disable-verify-certs/tests/test_default.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import testinfra.utils.ansible_runner
 
 testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 

--- a/tests/conjur_variable/test_cases/retrieve-variable-into-file/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-into-file/tests/test_default.py
@@ -3,7 +3,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import testinfra.utils.ansible_runner
 
 testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 

--- a/tests/conjur_variable/test_cases/retrieve-variable-no-cert-provided/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-no-cert-provided/tests/test_default.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import testinfra.utils.ansible_runner
 
 testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 

--- a/tests/conjur_variable/test_cases/retrieve-variable-with-authn-token-bad-cert/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-with-authn-token-bad-cert/tests/test_default.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import testinfra.utils.ansible_runner
 
 testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 

--- a/tests/conjur_variable/test_cases/retrieve-variable-with-authn-token/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-with-authn-token/tests/test_default.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import testinfra.utils.ansible_runner
 
 testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 

--- a/tests/conjur_variable/test_cases/retrieve-variable-with-spaces-secret/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable-with-spaces-secret/tests/test_default.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import testinfra.utils.ansible_runner
 
 testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 

--- a/tests/conjur_variable/test_cases/retrieve-variable/tests/test_default.py
+++ b/tests/conjur_variable/test_cases/retrieve-variable/tests/test_default.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import testinfra.utils.ansible_runner
+
 
 testinfra_hosts = [os.environ['COMPOSE_PROJECT_NAME'] + '-ansible']
 

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -7,3 +7,4 @@ ci/publish_to_galaxy shebang
 ci/test.sh shebang
 secrets.yml yamllint:unparsable-with-libyaml # File loaded by Summon utility (in Jenkinsfile), not via Python
 dev/policy/root.yml yamllint:unparsable-with-libyaml
+plugins/lookup/conjur_variable.py validate-modules:version-added-must-be-major-or-minor

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,0 +1,10 @@
+ci/build_release shebang
+ci/publish_to_galaxy shebang
+ci/test.sh shebang
+dev/policy/root.yml yamllint:unparsable-with-libyaml
+dev/start.sh shebang
+Jenkinsfile shebang
+plugins/lookup/conjur_variable.py validate-modules:version-added-must-be-major-or-minor # Lookup plugin added in v1.0.2
+roles/conjur_host_identity/tests/policy/root.yml yamllint:unparsable-with-libyaml # File loaded by Conjur server, not via Python
+secrets.yml yamllint:unparsable-with-libyaml # File loaded by Summon utility (in Jenkinsfile), not via Python
+tests/conjur_variable/policy/root.yml yamllint:unparsable-with-libyaml # File loaded by Conjur server, not via Python

--- a/tests/unit/plugins/lookup/test_conjur_variable.py
+++ b/tests/unit/plugins/lookup/test_conjur_variable.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from unittest import TestCase
-from unittest.mock import call, MagicMock, patch
+from unittest.mock import MagicMock, patch
 from ansible.errors import AnsibleError
 from ansible.plugins.loader import lookup_loader
 


### PR DESCRIPTION
**NOTE: Failing checks on `devel` can be ignored.**

### Desired Outcome

Jenkins build fails while testing the Host Identity role against Conjur Enterprise with the following message:
```
Error response from daemon: Address already in use
Error: failed to start containers: ${cli_cid} 
```

This is after Jenkins successfully runs the Variable Lookup plugin tests against Conjur Enterprise.

### Implemented Changes

- Destroy CLI container during cleanup
- Add daily trigger to Jenkinsfile
- Update Sanity and Unit test version matrix

### Connected Issue/Story

CNJR-2444

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
