### PR TITLE
Bugfixes: env consolidation, error wrapping

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -42,7 +42,7 @@ EOF
 function run_test {
   pushd "${PWD}/tests/${1}"
     echo "Running ${1} tests..."
-    ./test.sh "$flags"
+    ./test.sh
   popd
 }
 
@@ -51,7 +51,7 @@ function run_test {
 function run_role_test {
   pushd "${PWD}/roles/${1}/tests"
     echo "Running ${1} tests..."
-    ./test.sh "$flags"
+    ./test.sh
   popd
 }
 
@@ -112,7 +112,8 @@ done
 function main {
   if [[ "$start_dev_env" == "true" ]]; then
     pushd "$(dev_dir)"
-      ./start.sh "$flags"
+      # shellcheck disable=SC2046
+      ./start.sh $(echo "$flags" | cut -c 1-)
     popd
   fi
 

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -18,24 +18,27 @@ Conjur Ansible Collection :: Dev Environment
 $0 [options]
 
 -e            Deploy Conjur Enterprise. (Default: Conjur Open Source)
--h            Print usage information.
+-h, --help    Print usage information.
 -p <version>  Run the Ansible service with the desired Python version. (Default: 3.11)
 -v <version>  Run the Ansible service with the desired Ansible Community Package
               version. (Default: 8)
 EOF
 }
 
-while getopts ehp:v: option; do
-  case "$option" in
-    e) ENTERPRISE="true" ;;
-    h) help && exit 0 ;;
-    p) PYTHON_VERSION="${OPTARG}" ;;
-    v) ANSIBLE_VERSION="${OPTARG}" ;;
-    *)
+while true ; do
+  case "$1" in
+    -e ) ENTERPRISE="true" ; shift ;;
+    -h | --help ) help && exit 0 ;;
+    -p ) PYTHON_VERSION="$2" ; shift ; shift ;;
+    -v ) ANSIBLE_VERSION="$2" ; shift ; shift ;;
+    * )
+      if [[ -z "$1" ]]; then
+        break
+      else
         echo "$1 is not a valid option"
         help
         exit 1
-        ;;
+      fi ;;
   esac
 done
 

--- a/roles/conjur_host_identity/tasks/identity_check.yml
+++ b/roles/conjur_host_identity/tasks/identity_check.yml
@@ -9,12 +9,13 @@
     conjurized: "{{ identity_file.stat.exists|bool }}"
 
 - name: Ensure all required variables are set
-  fail: msg="Variable '{{ item }}' is not set!"
-  when: item is undefined
-  with_items:
-    - "{{ conjur_account }}"
-    - "{{ conjur_appliance_url }}"
-    - "{{ conjur_host_name }}"
+  fail:
+    msg: Variable '{{ item }}' is not set!
+  when: vars[item] is undefined
+  loop:
+    - conjur_account
+    - conjur_appliance_url
+    - conjur_host_name
 
 - name: Set fact "ssl_configuration"
   set_fact:
@@ -22,11 +23,12 @@
 
 - block:
   - name: Ensure all required ssl variables are set
-    fail: msg="Variable '{{ item }}' is not set!"
-    when: item is undefined
-    with_items:
-      - "{{ conjur_ssl_certificate }}"
-      - "{{ conjur_validate_certs }}"
+    fail:
+      msg: Variable '{{ item }}' is not set!
+    when: vars[item] is undefined
+    loop:
+      - conjur_ssl_certificate
+      - conjur_validate_certs
 
   - name: Set fact "ssl file path"
     set_fact:
@@ -46,8 +48,7 @@
 
 - block:
   - name: Ensure "conjur_host_factory_token" is set (if node is not already conjurized)
-    fail: msg="Variable '{{ item }}' is not set!"
-    when: item is undefined
-    with_items:
-      - "{{ conjur_host_factory_token }}"
+    fail:
+      msg: Variable 'conjur_host_factory_token' is not set!
+    when: conjur_host_factory_token is undefined
   when: not conjurized

--- a/roles/conjur_host_identity/tests/test_cases/bad-ssl-config/playbook.yml
+++ b/roles/conjur_host_identity/tests/test_cases/bad-ssl-config/playbook.yml
@@ -1,5 +1,5 @@
 ---
-- name: Configuring Conjur identity on remote hosts fails when missing required variable
+- name: Configuring Conjur identity on remote hosts fails when missing required SSL config
   hosts: testapp
   tasks:
     - name: Attempt to configure Conjur identity
@@ -8,13 +8,13 @@
             name: "cyberark.conjur.conjur-host-identity"
           vars:
             conjur_account: cucumber
-            # conjur_appliance_url: "https://conjur-proxy-nginx"
+            conjur_appliance_url: "https://conjur-proxy-nginx"
             conjur_host_factory_token: "{{lookup('env', 'HFTOKEN')}}"
             conjur_host_name: "conjur_{{ ansible_hostname }}"
-            conjur_ssl_certificate: "{{lookup('file', '/cyberark/dev/conjur.pem')}}"
+            # conjur_ssl_certificate: "{{lookup('file', '/cyberark/dev/conjur.pem')}}"
             conjur_validate_certs: yes
       rescue:
         - name: Confirm Role setup fails with message
           assert:
             that: ansible_failed_result.failed == true
-            fail_msg: "Variable 'conjur_appliance_url' is not set!"
+            fail_msg: "Variable 'conjur_ssl_certificate' is not set!"

--- a/roles/conjur_host_identity/tests/test_cases/not-conjurized/playbook.yml
+++ b/roles/conjur_host_identity/tests/test_cases/not-conjurized/playbook.yml
@@ -1,0 +1,28 @@
+---
+- name: Un-Conjurize remote hosts
+  hosts: testapp
+  tasks:
+    - name: Remove identity file
+      file:
+        path: /etc/conjur.identity
+        state: absent
+
+- name: Configuring Conjur identity on not-Conjurized hosts requires HF token
+  hosts: testapp
+  tasks:
+    - name: Attempt to configure Conjur identity
+      block:
+        - import_role:
+            name: "cyberark.conjur.conjur-host-identity"
+          vars:
+            conjur_account: "{{lookup('env', 'CONJUR_ACCOUNT')}}"
+            conjur_appliance_url: "{{lookup('env', 'CONJUR_APPLIANCE_URL')}}"
+            # conjur_host_factory_token: "{{lookup('env', 'HFTOKEN')}}"
+            conjur_host_name: "conjur_{{ ansible_hostname }}"
+            conjur_ssl_certificate: "{{lookup('file', '/cyberark/dev/conjur.pem')}}"
+            conjur_validate_certs: yes
+      rescue:
+        - name: Conjur Role setup fails with message
+          assert:
+            that: ansible_failed_result.failed == true
+            fail_msg: "Variable 'conjur_host_factory_token' is not set!"


### PR DESCRIPTION
### Desired Outcome

Fix Jenkins build:
```
[2023-09-19T14:26:02.124Z] TASK [Confirm error message] ***************************************************
[2023-09-19T14:26:02.124Z] fatal: [dev-test_app_ubuntu-1]: FAILED! => {
[2023-09-19T14:26:02.124Z]     "assertion": "ansible_failed_result.msg == \"'conjur_appliance_url' is undefined. 'conjur_appliance_url' is undefined\"",
[2023-09-19T14:26:02.124Z]     "changed": false,
[2023-09-19T14:26:02.124Z]     "evaluated_to": false,
[2023-09-19T14:26:02.124Z]     "msg": "Assertion failed"
[2023-09-19T14:26:02.124Z] }
[2023-09-19T14:26:02.379Z] fatal: [dev-test_app_ubuntu-2]: FAILED! => {
[2023-09-19T14:26:02.379Z]     "assertion": "ansible_failed_result.msg == \"'conjur_appliance_url' is undefined. 'conjur_appliance_url' is undefined\"",
[2023-09-19T14:26:02.379Z]     "changed": false,
[2023-09-19T14:26:02.379Z]     "evaluated_to": false,
[2023-09-19T14:26:02.379Z]     "msg": "Assertion failed"
[2023-09-19T14:26:02.379Z] }
[2023-09-19T14:26:02.379Z] fatal: [dev-test_app_centos-1]: FAILED! => {
[2023-09-19T14:26:02.379Z]     "assertion": "ansible_failed_result.msg == \"'conjur_appliance_url' is undefined. 'conjur_appliance_url' is undefined\"",
[2023-09-19T14:26:02.379Z]     "changed": false,
[2023-09-19T14:26:02.379Z]     "evaluated_to": false,
[2023-09-19T14:26:02.379Z]     "msg": "Assertion failed"
[2023-09-19T14:26:02.379Z] }
[2023-09-19T14:26:02.379Z] fatal: [dev-test_app_centos-2]: FAILED! => {
[2023-09-19T14:26:02.379Z]     "assertion": "ansible_failed_result.msg == \"'conjur_appliance_url' is undefined. 'conjur_appliance_url' is undefined\"",
[2023-09-19T14:26:02.379Z]     "changed": false,
[2023-09-19T14:26:02.379Z]     "evaluated_to": false,
[2023-09-19T14:26:02.379Z]     "msg": "Assertion failed"
[2023-09-19T14:26:02.379Z] }
```

### Implemented Changes

- Script `dev/start.sh` was not correctly parsing flags passed to it by `ci/test.sh`. This is fixed by manually parsing arguments instead of using `getopts`.
- Role was trying to wrap Ansible errors, but the technique was outdated. This has been updated.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
