### PR TITLE
Remove conjur-intro submodule from build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.2.2] - 2023-09-28
+
+### Changed
+- Bump required Ansible version to >= 2.13
+  [cyberark/ansible-conjur-collection#198](https://github.com/cyberark/ansible-conjur-collection/pull/198)
+- Ignore dev folder when building the collection
+  [cyberark/ansible-conjur-collection#198](https://github.com/cyberark/ansible-conjur-collection/pull/198)
+
 ## [1.2.1] - 2023-09-20
 
 ### Fixed
@@ -91,7 +99,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Migrated code from Ansible conjur_variable lookup plugin
 - Added support to configure the use of the plugin via environment variables
 
-[Unreleased]: https://github.com/cyberark/ansible-conjur-collection/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/cyberark/ansible-conjur-collection/compare/v1.2.2...HEAD
+[1.2.2]: https://github.com/cyberark/ansible-conjur-collection/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/cyberark/ansible-conjur-collection/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/cyberark/ansible-conjur-collection/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/cyberark/ansible-conjur-collection/compare/v1.0.7...v1.1.0

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ detailed information on our certification levels, see
 - An instance of [CyberArk Conjur Open Source](https://www.conjur.org) v1.x+ or [CyberArk
   Conjur Enterprise](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Resources/_TopNav/cc_Home.htm)
   (formerly DAP) v10.x+ accessible from the target node
-- Ansible >= 2.9
+- Ansible >= 2.13
 
 ## Using ansible-conjur-collection with Conjur Open Source
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "cyberark"
 name: "conjur"
-version: "1.2.1"
+version: "1.2.2"
 readme: README.md
 authors:
     - CyberArk Business Development (@cyberark-bizdev)
@@ -21,3 +21,5 @@ tags:
   - devops
 repository: "https://github.com/cyberark/ansible-conjur-collection"
 issues: "https://github.com/cyberark/ansible-conjur-collection/issues"
+build_ignore:
+  - "dev"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -23,3 +23,5 @@ repository: "https://github.com/cyberark/ansible-conjur-collection"
 issues: "https://github.com/cyberark/ansible-conjur-collection/issues"
 build_ignore:
   - "dev"
+  - "ci"
+  - "secrets.yml"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-    requires_ansible: '>=2.9'
+    requires_ansible: '>=2.13'


### PR DESCRIPTION
Address issues with the previous version uploading to Automation Hub:
- `dev` folder included in binary, resulting in sanity check and linting errors
- Bump `requires_ansible` key to `>= 2.13`

Also preps to release a new version (v1.2.2) with these changes
