### PR TITLE
Update Docker Compose Syntax, base images

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Before getting started, the following tools need to be installed:
 
 ## Set up a development environment
 
-The `dev` directory contains a `docker-compose` file which creates a development
+The `dev` directory contains a `docker-compose.yml` file which creates a development
 environment :
 -  A Conjur Open Source instance
 -  An Ansible control node
@@ -142,7 +142,7 @@ Generate the master key, which will be used to encrypt Conjur's database. Store
 this value as an environment variable.
 
 ```sh-session
-docker-compose run --no-deps --rm conjur data-key generate > data_key
+docker compose run --no-deps --rm conjur data-key generate > data_key
 export CONJUR_DATA_KEY="$(< data_key)"
 ```
 
@@ -150,20 +150,20 @@ Start the Conjur OSS environment. An account, named `cucumber`, will be
 automatically created.
 
 ```sh-session
-docker-compose up -d conjur
+docker compose up -d conjur
 ```
 
 Retrieve the admin user's API key, and store the value in an environment variable.
 
 ```sh-session
-export CLI_CONJUR_AUTHN_API_KEY="$(docker-compose exec conjur conjurctl role retrieve-key cucumber:user:admin)"
+export CLI_CONJUR_AUTHN_API_KEY="$(docker compose exec conjur conjurctl role retrieve-key cucumber:user:admin)"
 ```
 
 Start the Conjur CLI container. The CLI will be automatically authenticated as
 the user `cucumber:user:admin`.
 
 ```sh-session
-docker-compose up -d conjur_cli
+docker compose up -d conjur_cli
 ```
 
 ## Load policy to set up Conjur Ansible integration
@@ -174,15 +174,15 @@ be a policy, a host, a user, a layer, a group, or a variable.
 Check out the policy file, and load it into Conjur:
 
 ```sh-session
-docker-compose exec conjur_cli cat /policy/root.yml
-docker-compose exec conjur_cli conjur policy load root /policy/root.yml
+docker compose exec conjur_cli cat /policy/root.yml
+docker compose exec conjur_cli conjur policy load root /policy/root.yml
 ```
 
 Also, load a dummy secret value into the `ansible/target-password` variable.
 This is a variable required by remote nodes in order to complete their workloads.
 
 ```sh-session
-docker-compose exec conjur_cli conjur variable values add ansible/target-password S3cretV@lue
+docker compose exec conjur_cli conjur variable values add ansible/target-password S3cretV@lue
 ```
 
 ## Create Ansible managed nodes
@@ -192,15 +192,15 @@ nodes. First, retrieve the API key for the Conjur host representing the control
 node, then create it:
 
 ```sh-session
-export ANSIBLE_CONJUR_AUTHN_API_KEY="$(docker-compose exec conjur conjurctl role retrieve-key cucumber:host:ansible/ansible-master)"
-docker-compose up -d ansible
+export ANSIBLE_CONJUR_AUTHN_API_KEY="$(docker compose exec conjur conjurctl role retrieve-key cucumber:host:ansible/ansible-master)"
+docker compose up -d ansible
 ```
 
 Next, create two instances of each managed node:
 
 ```sh-session
-docker-compose up -d --scale test_app_ubuntu=2 test_app_ubuntu
-docker-compose up -d --scale test_app_centos=2 test_app_centos
+docker compose up -d --scale test_app_ubuntu=2 test_app_ubuntu
+docker compose up -d --scale test_app_centos=2 test_app_centos
 ```
 
 ## Use Conjur Ansible Role to set up identity on managed nodes
@@ -209,13 +209,13 @@ To grant your Ansible host a Conjur identity, first install the Conjur
 Collection on your Ansible control node:
 
 ```sh-session
-docker-compose exec ansible ansible-galaxy collection install cyberark.conjur
+docker compose exec ansible ansible-galaxy collection install cyberark.conjur
 ```
 
 Set up the host factory token in the HFTOKEN env var
 
 ```sh-session
-export HFTOKEN="$(docker-compose exec conjur_cli conjur hostfactory tokens create ansible/ansible-factory | jq -r '.[0].token')"
+export HFTOKEN="$(docker compose exec conjur_cli conjur hostfactory tokens create ansible/ansible-factory | jq -r '.[0].token')"
 ```
 
 Once you've done this, you can configure each Ansible node with a Conjur

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -69,17 +69,17 @@ function deploy_conjur_open_source() {
   echo "---- deploying Conur Open Source ----"
 
   # start conjur server
-  docker-compose up -d --build conjur conjur-proxy-nginx
-  set_conjur_cid "$(docker-compose ps -q conjur)"
+  docker compose up -d --build conjur conjur-proxy-nginx
+  set_conjur_cid "$(docker compose ps -q conjur)"
   wait_for_conjur
 
   # get admin credentials
-  fetch_conjur_cert "$(docker-compose ps -q conjur-proxy-nginx)" "cert.crt"
+  fetch_conjur_cert "$(docker compose ps -q conjur-proxy-nginx)" "cert.crt"
   ADMIN_API_KEY="$(user_api_key "$CONJUR_ACCOUNT" admin)"
 
   # start conjur cli and configure conjur
-  docker-compose up --no-deps -d conjur_cli
-  set_cli_cid "$(docker-compose ps -q conjur_cli)"
+  docker compose up --no-deps -d conjur_cli
+  set_cli_cid "$(docker compose ps -q conjur_cli)"
   setup_conjur_resources
 }
 
@@ -92,12 +92,12 @@ function deploy_conjur_enterprise {
     # start conjur leader and follower
     ./bin/dap --provision-master
     ./bin/dap --provision-follower
-    set_conjur_cid "$(docker-compose ps -q conjur-master.mycompany.local)"
+    set_conjur_cid "$(docker compose ps -q conjur-master.mycompany.local)"
 
     fetch_conjur_cert "$(conjur_cid)" "/etc/ssl/certs/ca.pem"
 
     # Run 'sleep infinity' in the CLI container so it stays alive
-    set_cli_cid "$(docker-compose run --no-deps -d -w /src/cli --entrypoint sleep client infinity)"
+    set_cli_cid "$(docker compose run --no-deps -d -w /src/cli --entrypoint sleep client infinity)"
     # Authenticate the CLI container
     docker exec "$(cli_cid)" /bin/sh -c "
       if [ ! -e /root/conjur-demo.pem ]; then
@@ -142,8 +142,8 @@ function main() {
   refresh_access_token "host/ansible/ansible-master" "$ANSIBLE_API_KEY"
 
   # start ansible control node
-  docker-compose up -d --build ansible
-  set_ansible_cid "$(docker-compose ps -q ansible)"
+  docker compose up -d --build ansible
+  set_ansible_cid "$(docker compose ps -q ansible)"
 
   # scale ansible managed nodes
   generate_inventory

--- a/dev/stop.sh
+++ b/dev/stop.sh
@@ -7,7 +7,7 @@ declare -x DOCKER_NETWORK='default'
 echo "---- removing dev environment----"
 cd "$(dev_dir)"
 
-docker-compose down -v
+docker compose down -v
 
 if [[ -n "$(cli_cid)" ]]; then
   docker rm -f "$(cli_cid)"

--- a/dev/test_app_centos/Dockerfile
+++ b/dev/test_app_centos/Dockerfile
@@ -1,4 +1,9 @@
-FROM centos:7
+FROM centos:latest
+
+# 
+RUN cd /etc/yum.repos.d/
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
 # Install Python so Ansible can run against node
 RUN yum update -y && yum install -y python3

--- a/dev/test_app_ubuntu/Dockerfile
+++ b/dev/test_app_ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Install Python so Ansible can run against node
 RUN apt-get update -y && apt-get install -y python3-minimal

--- a/dev/util.sh
+++ b/dev/util.sh
@@ -10,7 +10,7 @@ function dev_dir {
 }
 
 function compose_major_version {
-  docker-compose version --short | cut -d "." -f 1
+  docker compose version --short | cut -d "." -f 1
 }
 
 function set_network {
@@ -91,8 +91,8 @@ function teardown_and_setup_inventory {
   pushd "$(dev_dir)"
     # shellcheck disable=SC2155
     export DOCKER_NETWORK="$(network)"
-    docker-compose up -d --force-recreate --scale test_app_ubuntu=2 test_app_ubuntu
-    docker-compose up -d --force-recreate --scale test_app_centos=2 test_app_centos
+    docker compose up -d --force-recreate --scale test_app_ubuntu=2 test_app_ubuntu
+    docker compose up -d --force-recreate --scale test_app_centos=2 test_app_centos
   popd
 }
 


### PR DESCRIPTION
### Desired Outcome

- Use Docker Compose v2
- Update ubuntu and centos base images

### Implemented Changes

- Replace `docker-compose` with `docker compose`
- Update centos image to v8
- Update ubuntu image to 22.04

### Connected Issue/Story

CyberArk internal issue ID: CNJR-2127

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
