### PR TITLE
Fix the Sanity Test for Ansible 2.16 version

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -6,7 +6,8 @@
 # - stable-2.13 (3.8, 3.9, 3.10)
 # - stable-2.14 (3.9, 3.10, 3.11)
 # - stable-2.15 (3.9, 3.10, 3.11)
-# - devel       (3.10)
+# - stable-2.16 (3.10, 3.11, 3.12)
+# - devel       (3.11)
 #
 # As Ansible's devel version is unstable, it should be considered a smoke signal
 # for the next released version. Failures against the devel version should not
@@ -47,8 +48,14 @@ jobs:
             python: '3.11'
           - ansible: stable-2.15
             python: '3.11'
-          - ansible: devel
+          - ansible: stable-2.16
             python: '3.10'
+          - ansible: stable-2.16
+            python: '3.11'
+          - ansible: stable-2.16
+            python: '3.12'
+          - ansible: devel
+            python: '3.11'
 
     runs-on: ubuntu-latest
     steps:
@@ -104,8 +111,14 @@ jobs:
             python: '3.11'
           - ansible: stable-2.15
             python: '3.11'
-          - ansible: devel
+          - ansible: stable-2.16
             python: '3.10'
+          - ansible: stable-2.16
+            python: '3.11'
+          - ansible: stable-2.16
+            python: '3.12'
+          - ansible: devel
+            python: '3.11'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,0 +1,4 @@
+Jenkinsfile shebang
+plugins/lookup/conjur_variable.py validate-modules:version-added-must-be-major-or-minor
+dev/policy/root.yml yamllint:unparsable-with-libyaml # File loaded by Conjur server, not via Python
+secrets.yml yamllint:unparsable-with-libyaml # File loaded by Summon, not via Python

--- a/tests/unit/plugins/lookup/test_conjur_variable.py
+++ b/tests/unit/plugins/lookup/test_conjur_variable.py
@@ -27,15 +27,15 @@ class TestConjurLookup(TestCase):
             {},
             {'id': 'host/ansible/ansible-fake', 'api_key': 'fakekey'}
         )
-        self.assertEquals(MockMergeDictionaries.RESPONSE, functionOutput)
+        self.assertEqual(MockMergeDictionaries.RESPONSE, functionOutput)
 
     def test_load_identity_from_file(self):
         load_identity = _load_identity_from_file("/etc/conjur.identity", "https://conjur-fake")
-        self.assertEquals(MockFileload.RESPONSE, load_identity)
+        self.assertEqual(MockFileload.RESPONSE, load_identity)
 
     def test_load_conf_from_file(self):
         load_conf = _load_conf_from_file("/etc/conjur.conf")
-        self.assertEquals(MockFileload.RESPONSE, load_conf)
+        self.assertEqual(MockFileload.RESPONSE, load_conf)
 
     @patch('ansible_collections.cyberark.conjur.plugins.lookup.conjur_variable.open_url')
     def test_fetch_conjur_token(self, mock_open_url):
@@ -49,7 +49,7 @@ class TestConjurLookup(TestCase):
                                          method="POST",
                                          validate_certs=True,
                                          ca_path="cert_file")
-        self.assertEquals("response body", result)
+        self.assertEqual("response body", result)
 
     @patch('ansible_collections.cyberark.conjur.plugins.lookup.conjur_variable._repeat_open_url')
     def test_fetch_conjur_variable(self, mock_repeat_open_url):
@@ -63,7 +63,7 @@ class TestConjurLookup(TestCase):
                                                 method="GET",
                                                 validate_certs=True,
                                                 ca_path="cert_file")
-        self.assertEquals(['response body'], result)
+        self.assertEqual(['response body'], result)
 
     @patch('ansible_collections.cyberark.conjur.plugins.lookup.conjur_variable._fetch_conjur_variable')
     @patch('ansible_collections.cyberark.conjur.plugins.lookup.conjur_variable._fetch_conjur_token')
@@ -80,7 +80,7 @@ class TestConjurLookup(TestCase):
         kwargs = {'as_file': False, 'conf_file': 'conf_file', 'validate_certs': False}
         result = self.lookup.run(terms, **kwargs)
 
-        self.assertEquals(result, ["conjur_variable"])
+        self.assertEqual(result, ["conjur_variable"])
 
     @patch('ansible_collections.cyberark.conjur.plugins.lookup.conjur_variable._fetch_conjur_variable')
     @patch('ansible_collections.cyberark.conjur.plugins.lookup.conjur_variable._fetch_conjur_token')


### PR DESCRIPTION
### Desired Outcome

The goal of this PR is to resolve issues with the sanity and unit tests for Ansible 2.16, ensuring that the tests are executed successfully.

### Implemented Changes

- Added the ignore-2.16.txt file to skip the sanity tests.
- Included Ansible 2.16 with a compatible Python version in the workflow/ansible-test.yml.
- Updated the assertions in the unit tests for the lookup plugin to be compatible with Python 3.12.
- Updated the Python version to be compatible with the Ansible devel package.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
