### PR TITLE
Add jwt token authentication to the lookup plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ The Conjur Ansible Lookup Plugin allows you to securely fetch credentials from C
 
 - GCP Authentication (via IMDS token)
 
+- JWT Token Authentication
+
 Each authentication method retrieves secrets from Conjur dynamically, ensuring secure and seamless integration with cloud environments and Conjur.
 
 ### Authentication Parameters
@@ -278,6 +280,26 @@ This method allows you to authenticate using a Google Cloud Platform (GCP) Servi
 #### How GCP Authentication Works
 
 For GCP Authentication, the plugin uses Google Cloud Instance Metadata Service (IMDS) to authenticate the workload by retrieving a JWT token. The token is used to authenticate against Secrets Manager, allowing the plugin to fetch the requested secrets securely.
+
+#### 5. JWT token Authentication
+This method uses jwt tokens for authentication.
+
+#### Required Extra-vars/Environment Variables:
+- `conjur_authn_type / CONJUR_AUTHN_TYPE` : Authentication type ("jwt").
+
+- `conjur_appliance_url / CONJUR_APPLIANCE_URL`: URL of the running Secrets Manager service (e.g., https://conjur.example.com).
+
+- `conjur_authn_login / CONJUR_AUTHN_LOGIN`: The identity of the Secrets Manager host (e.g., host/my-host).
+
+- `conjur_authn_service_id / CONJUR_AUTHN_SERVICE_ID`: The service ID as used for the JWT token Authenticator.
+
+#### Optional Extra-vars/Environment Variables:
+- `conjur_account / CONJUR_ACCOUNT`: The Secrets Manager account name (default: conjur).
+
+- `conjur_cert_content / CONJUR_CERT_CONTENT`: Content of the Secrets Manager certificate (PEM format).
+
+- `conjur_cert_file / CONJUR_CERT_FILE`: Path to the Secrets Manager certificate file.
+
 
 ### Example Playbooks and Ansible Commands
 
@@ -473,6 +495,58 @@ export CONJUR_AUTHN_TYPE="gcp"
 export CONJUR_APPLIANCE_URL="https://conjur.example.com"
 export CONJUR_ACCOUNT="myaccount"
 export CONJUR_AUTHN_LOGIN="host/testapp"
+export CONJUR_CERT_FILE="<path>/certificate.pem"
+```
+
+```sh
+ansible-playbook -v retrieve-secrets.yaml
+```
+
+#### 5. JWT token Authentication
+
+##### Playbook Example:
+
+```yaml
+---
+- hosts: localhost
+  collections:
+    - cyberark.conjur
+  tasks:
+    - name: Lookup variable in Secrets Manager
+      debug:
+        msg: "{{ lookup('cyberark.conjur.conjur_variable', 'data/ansible/target-secret') }}"
+```
+##### Using with Extra-vars:
+
+```sh
+ansible-playbook -v \
+--extra-vars "conjur_authn_type=jwt" \
+--extra-vars "conjur_appliance_url=https://conjur.example.com" \
+--extra-vars "conjur_authn_login=host/my-host" \
+--extra-vars "conjur_authn_service_id=<your_conjur_service_id>" \
+--extra-vars "conjur_cert_file=<path>/certificate.pem" retrieve-secrets.yaml
+```
+
+Alternatively, to provide the certificate content in PEM format as a string:
+
+```sh
+ansible-playbook -v \
+--extra-vars "conjur_authn_type=jwt" \
+--extra-vars "conjur_appliance_url=https://conjur.example.com" \
+--extra-vars "conjur_authn_jwt_token=<token>" \
+--extra-vars "conjur_authn_login=host/my-host" \
+--extra-vars "conjur_authn_service_id=<your_conjur_service_id>" \
+--extra-vars "conjur_cert_content='-----BEGIN CERTIFICATE-----\n<your certificate content>\n-----END CERTIFICATE-----\n'" retrieve-secrets.yaml
+```
+#### Using with Environment variables:
+
+```sh
+export CONJUR_AUTHN_TYPE="jwt"
+export CONJUR_APPLIANCE_URL="https://conjur.example.com"
+export CONJUR_ACCOUNT="myaccount"
+export CONJUR_AUTHN_JWT_TOKEN="token"
+export CONJUR_AUTHN_LOGIN="host/testapp"
+export CONJUR_AUTHN_SERVICE_ID="<your_conjur_service_id>"
 export CONJUR_CERT_FILE="<path>/certificate.pem"
 ```
 

--- a/plugins/lookup/conjur_variable.py
+++ b/plugins/lookup/conjur_variable.py
@@ -789,6 +789,7 @@ def _fetch_conjur_jwt_token(
         raise AnsibleError(f"Error fetching identity token: {str(error)}") from error
     finally:
         token = None
+        jwt_token = None
 
 def retry(retries, retry_interval):
     """
@@ -1075,7 +1076,7 @@ class LookupModule(LookupBase):
             cert_file = _get_certificate_file(cert_content, cert_file)
 
         if authn_type in ("aws", "azure", "jwt") and service_id is None:
-            raise AnsibleError("[WARNING]: Please set the conjur_authn_service_id for AWS or Azure authenticator")
+            raise AnsibleError("[WARNING]: Please set the conjur_authn_service_id for AWS, Azure or JWT. authenticator")
 
         if not account:
             display.vvv("No conjur account provided. Defaulting to 'conjur'.")

--- a/plugins/lookup/conjur_variable.py
+++ b/plugins/lookup/conjur_variable.py
@@ -1076,7 +1076,7 @@ class LookupModule(LookupBase):
             cert_file = _get_certificate_file(cert_content, cert_file)
 
         if authn_type in ("aws", "azure", "jwt") and service_id is None:
-            raise AnsibleError("[WARNING]: Please set the conjur_authn_service_id for AWS, Azure or JWT. authenticator")
+            raise AnsibleError("[WARNING]: Please set the conjur_authn_service_id for AWS, Azure or JWT authenticator")
 
         if not account:
             display.vvv("No conjur account provided. Defaulting to 'conjur'.")


### PR DESCRIPTION
### Desired Outcome

The ansible lookup plugin will now support the authn-jwt endpoint, so I can retrieve secrets using a jwt token. This has been a blocker for us to adopt conjur.

### Implemented Changes

Added an _fetch_conjur_jwt_token to retrieve an authentication token through a jwt token

### Connected Issue/Story

Resolves #[145](https://github.com/cyberark/ansible-conjur-collection/issues/145)
Resolves #[146](https://github.com/cyberark/ansible-conjur-collection/issues/146)

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [X] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
