### PR TITLE
Add encrypted cache mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ This method allows you to authenticate using a Google Cloud Platform (GCP) Servi
 
 - `conjur_cert_file / CONJUR_CERT_FILE`: Path to the Secrets Manager certificate file.
 
+- 
+
 #### How GCP Authentication Works
 
 For GCP Authentication, the plugin uses Google Cloud Instance Metadata Service (IMDS) to authenticate the workload by retrieving a JWT token. The token is used to authenticate against Secrets Manager, allowing the plugin to fetch the requested secrets securely.
@@ -558,6 +560,24 @@ ansible_ssh_private_key_file: "{{ lookup('cyberark.conjur.conjur_variable', 'pat
 
 **Note:** Using the `as_file=true` condition, the private key is stored in a temporary file and its path is written 
 in `ansible_ssh_private_key_file`.
+
+
+#### Retrieve a secret in play vars using the cache
+
+```yaml
+---
+- hosts: localhost
+  vars:
+    my_secret: "{{ lookup('cyberark.conjur.conjur_variable', 'path/to/secret-id', use_cache=true) }}"
+  tasks:
+  - name: This will call the plugin and cache the secret value for future lookups
+    debug:
+      msg: "my_secret with value {{ my_secret }} has just been stored in the cache."
+  - name: This will retrieve the secret value from the cache without calling the plugin
+    debug:
+      msg: "my_secret with value {{ my_secret }} has been retrieved from the cache without calling Conjur."
+```
+**Note:** Using the `use_cache=true` condition, the secret value is stored in an encrypted cache file after the first retrieval. Subsequent lookups for the same secret will retrieve the value from the cache. The cache file, stored in the temporary directory, is encrypted using PBKDF2HMAC with a unique salt and the Fernet symmetric encryption method.
 
 ## Contributing
 

--- a/plugins/lookup/conjur_variable.py
+++ b/plugins/lookup/conjur_variable.py
@@ -1090,12 +1090,16 @@ class LookupModule(LookupBase):
         # Check cache if cacheable is enabled
         if cacheable:
             cache_key = f"{conf['appliance_url']}|{terms[0]}"
+            display.vvv(f"Cache enabled. Cache key: {cache_key}")
+            display.vvv(f"Current cache size: {len(LookupModule._variable_cache)} entries")
             if cache_key in LookupModule._variable_cache:
-                display.vvv(f"Retrieving variable {terms[0]} from cache")
+                display.vvv(f"Cache HIT: Retrieving variable {terms[0]} from cache")
                 cached_value = LookupModule._variable_cache[cache_key]
                 if as_file:
                     return _store_secret_in_file(cached_value)
                 return cached_value
+            else:
+                display.vvv(f"Cache MISS: Variable {terms[0]} not in cache, will fetch from Conjur")
 
         try:
             token = None
@@ -1156,7 +1160,7 @@ class LookupModule(LookupBase):
             if cacheable:
                 cache_key = f"{conf['appliance_url']}|{terms[0]}"
                 LookupModule._variable_cache[cache_key] = conjur_variable
-                display.vvv(f"Cached variable {terms[0]}")
+                display.vvv(f"Stored variable {terms[0]} in cache (total entries: {len(LookupModule._variable_cache)})")
         finally:
             if isinstance(token, bytes):
                 token = b"\x00" * len(token)

--- a/plugins/lookup/conjur_variable.py
+++ b/plugins/lookup/conjur_variable.py
@@ -230,7 +230,7 @@ try:
     from cryptography.hazmat.backends import default_backend
     from cryptography.fernet import Fernet
     from cryptography.hazmat.primitives import hashes
-    from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2
+    from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 except ImportError:
     cryptography_import_error = traceback.format_exc()
 else:
@@ -1000,8 +1000,8 @@ class LookupModule(LookupBase):
             # Combine multiple machine identifiers
             machine_id = f"{platform.node()}-{uuid.getnode()}".encode()
             
-            # Derive a key using PBKDF2
-            kdf = PBKDF2(
+            # Derive a key using PBKDF2HMAC
+            kdf = PBKDF2HMAC(
                 algorithm=hashes.SHA256(),
                 length=32,
                 salt=b'ansible-conjur-cache-salt',  # Static salt for deterministic key

--- a/plugins/lookup/conjur_variable.py
+++ b/plugins/lookup/conjur_variable.py
@@ -1032,10 +1032,6 @@ class LookupModule(LookupBase):
         if authn_type in ("aws", "azure") and service_id is None:
             raise AnsibleError("[WARNING]: Please set the conjur_authn_service_id for AWS or Azure authenticator")
 
-        if not account:
-            display.vvv("No conjur account provided. Defaulting to 'conjur'.")
-            account = "conjur"
-
         conf = _merge_dictionaries(
             _load_conf_from_file(conf_file),
             {
@@ -1052,6 +1048,14 @@ class LookupModule(LookupBase):
             } if authn_token_file is not None
             else {}
         )
+
+        if not account:
+            display.vvv("No conjur account provided. Defaulting to 'conjur'.")
+            account = "conjur"
+
+        # Update conf with the final account value
+        if 'account' not in conf or not conf['account']:
+            conf['account'] = account
 
         if 'appliance_url' not in conf:
             raise AnsibleError(

--- a/plugins/lookup/conjur_variable.py
+++ b/plugins/lookup/conjur_variable.py
@@ -174,14 +174,16 @@ DOCUMENTATION = """
           - name: azure_client_id
         env:
           - name: AZURE_CLIENT_ID
-      cacheable:
-        description: >-
-          Enable caching of retrieved variable values. When set to true, the lookup result
-          will be cached and subsequent lookups for the same variable will return the cached
-          value without contacting Conjur. Cache is scoped per appliance URL, account, and variable path.
+      use_cache:
+        description: Enable caching of retrieved variable values and alleviate the load on the Conjur server.
         type: boolean
         default: false
         required: false
+        ini:
+          - section: conjur,
+            key: use_cache
+        env:
+            - name: CONJUR_USE_CACHE
 """
 
 EXAMPLES = """
@@ -1092,7 +1094,7 @@ class LookupModule(LookupBase):
         validate_certs = self.get_option('validate_certs')
         conf_file = self.get_option('config_file')
         as_file = self.get_option('as_file')
-        cacheable = self.get_option('cacheable')
+        use_cache = self.get_option('use_cache')
 
         if validate_certs is False:
             display.warning('Certificate validation has been disabled. Please enable with validate_certs option.')
@@ -1161,8 +1163,8 @@ class LookupModule(LookupBase):
             display.vvv(f"Using cert file path {conf['cert_file']}")
             cert_file = conf['cert_file']
 
-        # Check cache if cacheable is enabled
-        if cacheable:
+        # Check cache if use_cache is enabled
+        if use_cache:
             cache = self._load_cache()
             cache_key = f"{conf['appliance_url']}|{terms[0]}"
             display.vvv(f"Cache enabled. Cache key: {cache_key}")
@@ -1231,9 +1233,8 @@ class LookupModule(LookupBase):
                 cert_file
             )
 
-            # Store in cache if cacheable is enabled
-            if cacheable:
-                cache = self._load_cache()
+            # Store in cache if use_cache is enabled
+            if use_cache:
                 cache_key = f"{conf['appliance_url']}|{terms[0]}"
                 cache[cache_key] = conjur_variable
                 self._save_cache(cache)

--- a/plugins/lookup/conjur_variable.py
+++ b/plugins/lookup/conjur_variable.py
@@ -182,8 +182,10 @@ DOCUMENTATION = """
         ini:
           - section: conjur,
             key: use_cache
+        vars:
+          - name: conjur_use_cache
         env:
-            - name: CONJUR_USE_CACHE
+          - name: CONJUR_USE_CACHE
 """
 
 EXAMPLES = """

--- a/plugins/lookup/conjur_variable.py
+++ b/plugins/lookup/conjur_variable.py
@@ -1032,6 +1032,10 @@ class LookupModule(LookupBase):
         if authn_type in ("aws", "azure") and service_id is None:
             raise AnsibleError("[WARNING]: Please set the conjur_authn_service_id for AWS or Azure authenticator")
 
+        if not account:
+            display.vvv("No conjur account provided. Defaulting to 'conjur'.")
+            account = "conjur"
+
         conf = _merge_dictionaries(
             _load_conf_from_file(conf_file),
             {
@@ -1048,14 +1052,6 @@ class LookupModule(LookupBase):
             } if authn_token_file is not None
             else {}
         )
-
-        if not account:
-            display.vvv("No conjur account provided. Defaulting to 'conjur'.")
-            account = "conjur"
-
-        # Update conf with the final account value
-        if 'account' not in conf or not conf['account']:
-            conf['account'] = account
 
         if 'appliance_url' not in conf:
             raise AnsibleError(
@@ -1093,7 +1089,7 @@ class LookupModule(LookupBase):
 
         # Check cache if cacheable is enabled
         if cacheable:
-            cache_key = f"{conf['appliance_url']}|{conf['account']}|{terms[0]}"
+            cache_key = f"{conf['appliance_url']}|{terms[0]}"
             if cache_key in LookupModule._variable_cache:
                 display.vvv(f"Retrieving variable {terms[0]} from cache")
                 cached_value = LookupModule._variable_cache[cache_key]
@@ -1158,7 +1154,7 @@ class LookupModule(LookupBase):
 
             # Store in cache if cacheable is enabled
             if cacheable:
-                cache_key = f"{conf['appliance_url']}|{conf['account']}|{terms[0]}"
+                cache_key = f"{conf['appliance_url']}|{terms[0]}"
                 LookupModule._variable_cache[cache_key] = conjur_variable
                 display.vvv(f"Cached variable {terms[0]}")
         finally:


### PR DESCRIPTION
### Desired Outcome

When activated, the secrets should be stored locally during the playbook runtime. This is to avoid unnecessary API Calls to Conjur.
This PR resolves our issue by introducing an optional encrypted cache mechanism.


### Implemented Changes

- You can enable cache by setting "use_cache=true" parameter in the lookup, using env var CONJUR_USE_CACHE or ini [conjur] use_cache
- When enabled, an encrypted file called ansible_conjur_cache.pkl will be created in tempdir and store a cache key and the secret.
- Logging have been added to help monitoring the behavior, set debug to 3 in Ansible and you'll get notified when cache is hit or missed (in which case it will be populated)
- If all goes well you should now notice only one Conjur call per secret, and one CACHE MISS
- This is of course not always desired, when running in temporary Execution Environment you know that these tempfiles won't survive the run, when not you don't. Sometimes you also might want your playbook to fetch secrets that have been updated during its run. That's why it's set as optional and false by default.


### Connected Issue/Story

Our implementation of the lookup plugins for connection variables inside the hostvars results in systematic evaluation of the lookup for every task and for every secret of every host in the play. This was inducing heavy and in our case unnecessary load on our Conjur Server.

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [X] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
